### PR TITLE
[Bugfix][Platform] Restore selector and hybrid KV cache compatibility

### DIFF
--- a/tests/ut/patch/platform/test_patch_selector.py
+++ b/tests/ut/patch/platform/test_patch_selector.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from vllm_ascend.patch.platform import patch_selector
+
+
+def test_get_attn_backend_supports_legacy_block_size_argument():
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            user_specified_block_size=False,
+            block_size=256,
+        ),
+        attention_config=SimpleNamespace(backend="ascend"),
+    )
+
+    with patch("vllm.config.get_current_vllm_config", return_value=vllm_config):
+        with patch(
+            "vllm_ascend.patch.platform.patch_selector._cached_get_attn_backend",
+            return_value="backend",
+        ) as mock_cached:
+            result = patch_selector.get_attn_backend(
+                0,
+                torch.bfloat16,
+                None,
+                128,
+                use_mla=True,
+                use_sparse=True,
+                use_compress=True,
+            )
+
+    assert result == "backend"
+    selector_config = mock_cached.call_args.kwargs["attn_selector_config"]
+    assert selector_config.block_size == 128
+    assert selector_config.use_mla is True
+    assert selector_config.use_sparse is True
+    assert selector_config.use_compress is True
+
+
+def test_get_attn_backend_uses_user_block_size_for_new_signature_calls():
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            user_specified_block_size=True,
+            block_size=64,
+        ),
+        attention_config=SimpleNamespace(backend="ascend"),
+    )
+
+    with patch("vllm.config.get_current_vllm_config", return_value=vllm_config):
+        with patch(
+            "vllm_ascend.patch.platform.patch_selector._cached_get_attn_backend",
+            return_value="backend",
+        ) as mock_cached:
+            result = patch_selector.get_attn_backend(
+                0,
+                torch.bfloat16,
+                None,
+                use_mla=False,
+                use_sparse=False,
+                use_per_head_quant_scales=True,
+                num_heads=32,
+            )
+
+    assert result == "backend"
+    selector_config = mock_cached.call_args.kwargs["attn_selector_config"]
+    assert selector_config.block_size == 64
+    assert selector_config.use_per_head_quant_scales is True
+    assert mock_cached.call_args.kwargs["num_heads"] == 32

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1,6 +1,7 @@
+from collections import defaultdict
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
@@ -15,14 +16,29 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.device = torch.device("cpu")
         runner.use_sparse = False
         runner.use_sparse_c8_indexer = False
+        runner.use_compress = False
         runner.use_hybrid_blocks = False
         runner.hybrid_with_attn_and_mamba = False
         runner.runner_only_attn_layers = set()
         runner.is_kv_consumer = False
         runner.vllm_config = MagicMock()
         runner.vllm_config.kv_transfer_config = None
+        runner.vllm_config.speculative_config = None
         runner.model_config = MagicMock()
         runner.model_config.use_mla = True
+        runner.model_config.get_vocab_size.return_value = 32000
+        runner.block_size = 128
+        runner.cache_config = SimpleNamespace(block_size=128)
+        runner.offload_config = SimpleNamespace(
+            uva=SimpleNamespace(cpu_offload_gb=0),
+        )
+        runner.max_num_reqs = 8
+        runner.max_model_len = 128
+        runner.max_encoder_len = 0
+        runner.max_num_tokens = 128
+        runner.pin_memory = False
+        runner.is_pooling_model = False
+        runner.input_batch = SimpleNamespace(logitsprocs=[])
         backend = MagicMock()
         backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
             2,
@@ -84,6 +100,105 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
 
+    def test_reshape_kv_cache_uses_selected_kernel_block_size_for_hybrid_group(self):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        runner.kernel_block_sizes = [[32]]
+        runner.attn_backend.get_supported_kernel_block_sizes.return_value = [128, 32]
+
+        kv_cache_spec = FullAttentionSpec(
+            block_size=32,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[KVCacheTensor(size=kv_cache_spec.page_size_bytes * 2, shared_by=["draft_attn"])],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=["draft_attn"],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+        kv_cache_raw_tensors = runner._allocate_kv_cache_tensors(kv_cache_config)
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_group_id=0,
+                kv_cache_spec=kv_cache_spec,
+                backend=runner.attn_backend,
+                layer_names=["draft_attn"],
+            )
+        ]
+
+        kv_caches = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            kv_cache_raw_tensors,
+        )
+        k_cache, v_cache = kv_caches["draft_attn"]
+
+        self.assertEqual(k_cache.shape, (2, 32, 8, 64))
+        self.assertEqual(v_cache.shape, (2, 32, 8, 64))
+        runner.attn_backend.get_kv_cache_shape.assert_any_call(2, 32, 8, 64)
+
+    def test_store_layer_attn_metadata_keeps_single_object_for_normal_model(self):
+        runner = self._build_runner()
+        attn_metadata_dict = {}
+        metadata_a = SimpleNamespace(name="a")
+
+        runner._store_layer_attn_metadata(attn_metadata_dict, "layer", metadata_a)
+        self.assertIs(attn_metadata_dict["layer"], metadata_a)
+
+    def test_store_layer_attn_metadata_appends_for_compress_model(self):
+        runner = self._build_runner()
+        runner.use_compress = True
+        attn_metadata_dict = defaultdict(list)
+        metadata_a = SimpleNamespace(name="a")
+        metadata_b = SimpleNamespace(name="b")
+
+        runner._store_layer_attn_metadata(attn_metadata_dict, "layer", metadata_a)
+        runner._store_layer_attn_metadata(attn_metadata_dict, "layer", metadata_b)
+
+        self.assertEqual(attn_metadata_dict["layer"], [metadata_a, metadata_b])
+
+    def test_may_reinitialize_input_batch_keeps_group_block_size_when_common_selector_has_no_match(self):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        backend = MagicMock()
+        backend.get_supported_kernel_block_sizes.return_value = [128]
+        runner.attn_groups = [[SimpleNamespace(backend=backend)]]
+        kv_cache_spec = FullAttentionSpec(
+            block_size=32,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=["draft_attn"],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+
+        with patch(
+            "vllm_ascend.worker.model_runner_v1.select_common_block_size",
+            side_effect=ValueError("No common block size for 32."),
+        ):
+            with patch("vllm_ascend.worker.model_runner_v1.NPUInputBatch") as mock_input_batch:
+                runner.may_reinitialize_input_batch(kv_cache_config)
+
+        self.assertEqual(runner.kernel_block_sizes, [[32]])
+        self.assertEqual(
+            mock_input_batch.call_args.kwargs["kernel_block_sizes"],
+            [[32]],
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -161,6 +161,10 @@ class AscendDSABackend(AttentionBackend):
         return AscendDSAImpl
 
     @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        return [128]
+
+    @staticmethod
     def get_supported_block_size() -> list[int]:
         return [32, 64, 128, 1024]
 

--- a/vllm_ascend/patch/platform/patch_selector.py
+++ b/vllm_ascend/patch/platform/patch_selector.py
@@ -6,6 +6,7 @@ from vllm.config.cache import CacheDType
 from vllm.v1.attention.backend import AttentionBackend, AttentionType
 from vllm.v1.attention.selector import _cached_get_attn_backend
 
+
 class AttentionSelectorConfig(NamedTuple):
     head_size: int
     dtype: torch.dtype
@@ -16,6 +17,7 @@ class AttentionSelectorConfig(NamedTuple):
     use_compress: bool = False
     use_sparse: bool = False
     use_mm_prefix: bool = False
+    use_per_head_quant_scales: bool = False
     attn_type: str = AttentionType.DECODER
 
     def __repr__(self):
@@ -28,6 +30,7 @@ class AttentionSelectorConfig(NamedTuple):
                 f"use_compress={self.use_compress}, "
                 f"use_sparse={self.use_sparse}, "
                 f"use_mm_prefix={self.use_mm_prefix}, "
+                f"use_per_head_quant_scales={self.use_per_head_quant_scales}, "
                 f"attn_type={self.attn_type})")
 
 
@@ -35,13 +38,15 @@ def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
     kv_cache_dtype: str | None,
-    block_size: int | None,
+    block_size: int | None = None,
     use_mla: bool = False,
     has_sink: bool = False,
     use_compress: bool = False,
     use_sparse: bool = False,
     use_mm_prefix: bool = False,
+    use_per_head_quant_scales: bool = False,
     attn_type: str | None = None,
+    num_heads: int | None = None,
 ) -> type[AttentionBackend]:
     """Selects which attention backend to use and lazily imports it."""
 
@@ -55,6 +60,9 @@ def get_attn_backend(
 
     vllm_config = get_current_vllm_config()
     backend_enum = vllm_config.attention_config.backend
+    cache_config = vllm_config.cache_config
+    if block_size is None and cache_config is not None and cache_config.user_specified_block_size:
+        block_size = cache_config.block_size
 
     attn_selector_config = AttentionSelectorConfig(
         head_size=head_size,
@@ -66,12 +74,14 @@ def get_attn_backend(
         use_compress=use_compress,
         use_sparse=use_sparse,
         use_mm_prefix=use_mm_prefix,
+        use_per_head_quant_scales=use_per_head_quant_scales,
         attn_type=attn_type or AttentionType.DECODER,
     )
 
     return _cached_get_attn_backend(
         backend=backend_enum,
         attn_selector_config=attn_selector_config,
+        num_heads=num_heads,
     )
 
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -49,7 +49,6 @@ from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
-from vllm.v1.attention.selector import get_attn_backend  # type: ignore
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.worker.utils import select_common_block_size
 from vllm.v1.kv_cache_interface import (
@@ -93,6 +92,7 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, using_paged_attention
+from vllm_ascend.patch.platform.patch_selector import get_attn_backend
 
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -237,6 +237,20 @@ class ExecuteModelState(NamedTuple):
 
 
 class NPUModelRunner(GPUModelRunner):
+    def _store_layer_attn_metadata(
+        self,
+        attn_metadata_dict: dict[str, Any],
+        layer_name: str,
+        attn_metadata: AttentionMetadata,
+    ) -> None:
+        if self.use_compress:
+            # TODO(#57): Refactor the per-layer attention metadata container so
+            # compressed multi-group models do not need a separate list-based
+            # path here.
+            attn_metadata_dict[layer_name].append(attn_metadata)
+        else:
+            attn_metadata_dict[layer_name] = attn_metadata
+
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         # TODO(qcs): These manual pad and unpad for GPUModelRunner are
         # used to expand some buffers, which need to be reverted after
@@ -2047,13 +2061,15 @@ class NPUModelRunner(GPUModelRunner):
             return {}, None
         num_tokens_padded = num_tokens_padded or num_tokens
         num_reqs_padded = num_reqs_padded or num_reqs
-        
+
         # check
-        # attn_metadata: PerLayerAttnMetadata = {}
-        attn_metadata: dict[str, Any] = defaultdict(list)
-        
+        attn_metadata: PerLayerAttnMetadata = defaultdict(list) if self.use_compress else {}
+
         if ubatch_slices is not None:
-            attn_metadata = [dict() for _ in range(len(ubatch_slices))]
+            attn_metadata = [
+                defaultdict(list) if self.use_compress else {}
+                for _ in range(len(ubatch_slices))
+            ]
         if for_cudagraph_capture:
             # For some attention backends (e.g. FA) with sliding window models we need
             # to make sure the backend see a max_seq_len that is larger to the sliding
@@ -2180,10 +2196,10 @@ class NPUModelRunner(GPUModelRunner):
             attn_gid: int,
             common_attn_metadata: CommonAttentionMetadata,
             num_reqs_actual: int,
-            prefill_ratio_to_sas_metadata: dict,
-            decode_ratio_to_sas_metadata: dict,
             ubid: int | None = None,
         ) -> None:
+            nonlocal prefill_ratio_to_sas_metadata
+            nonlocal decode_ratio_to_sas_metadata
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
             cascade_attn_prefix_len = (
@@ -2227,8 +2243,9 @@ class NPUModelRunner(GPUModelRunner):
                     and isinstance(builder, GDNAttentionMetadataBuilder) and attn_metadata_i.num_prefills == 0:
                     if attn_metadata_i.num_decodes == 0 and attn_metadata_i.num_spec_decodes > 0:
                         attn_metadata_i.spec_state_indices_tensor[attn_metadata_i.num_spec_decodes:].fill_(0)
-            prefill_ratio_to_sas_metadata = builder.prefill_ratio_to_sas_metadata
-            decode_ratio_to_sas_metadata = builder.decode_ratio_to_sas_metadata
+            if isinstance(builder, AscendDSAMetadataBuilder):
+                prefill_ratio_to_sas_metadata = builder.prefill_ratio_to_sas_metadata
+                decode_ratio_to_sas_metadata = builder.decode_ratio_to_sas_metadata
 
             if ubid is None:
                 assert isinstance(attn_metadata, dict)
@@ -2238,7 +2255,11 @@ class NPUModelRunner(GPUModelRunner):
                 attn_metadata_dict = attn_metadata[ubid]
 
             for layer_name in attn_group.layer_names:
-                attn_metadata_dict[layer_name].append(attn_metadata_i)
+                self._store_layer_attn_metadata(
+                    attn_metadata_dict,
+                    layer_name,
+                    attn_metadata_i,
+                )
 
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
@@ -2276,7 +2297,12 @@ class NPUModelRunner(GPUModelRunner):
                     spec_decode_common_attn_metadata = cm
 
             for attn_gid in range(len(self.attn_groups[kv_cache_gid])):
-                _build_attn_group_metadata(kv_cache_gid, attn_gid, cm, num_reqs_actual, prefill_ratio_to_sas_metadata, decode_ratio_to_sas_metadata)
+                _build_attn_group_metadata(
+                    kv_cache_gid,
+                    attn_gid,
+                    cm,
+                    num_reqs_actual,
+                )
         if self.is_mm_prefix_lm:
             req_doc_ranges = {}
             for req_id in self.input_batch.req_ids:
@@ -2292,10 +2318,18 @@ class NPUModelRunner(GPUModelRunner):
             if isinstance(attn_metadata, list):
                 for ub_metadata in attn_metadata:
                     for _metadata in ub_metadata.values():
-                        _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                        if self.use_compress:
+                            for metadata_i in _metadata:
+                                metadata_i.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                        else:
+                            _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
             else:
                 for _metadata in attn_metadata.values():
-                    _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                    if self.use_compress:
+                        for metadata_i in _metadata:
+                            metadata_i.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                    else:
+                        _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
 
         if spec_decode_common_attn_metadata is not None and (
             num_reqs != num_reqs_padded or num_tokens != num_tokens_padded
@@ -3032,8 +3066,19 @@ class NPUModelRunner(GPUModelRunner):
 
                     if hasattr(attn_backend, "get_supported_kernel_block_sizes") and self.use_hybrid_blocks:
                         block_size = attn_backend.get_supported_kernel_block_sizes()[0]
-
+                        if group.kv_cache_group_id < len(self.kernel_block_sizes):
+                            kernel_block_size = self.kernel_block_sizes[group.kv_cache_group_id]
+                            if isinstance(kernel_block_size, list):
+                                if kernel_block_size:
+                                    block_size = int(kernel_block_size[0])
+                            else:
+                                block_size = int(kernel_block_size)
                         block_size_chunk = current_kv_cache_spec.block_size // block_size
+                        assert block_size_chunk > 0, (
+                            "Selected kernel block size must not exceed the KV cache "
+                            f"block size: selected={block_size}, "
+                            f"kv_cache={current_kv_cache_spec.block_size}"
+                        )
                         kv_cache_shape = attn_backend.get_kv_cache_shape(
                             num_blocks * block_size_chunk,
                             block_size,
@@ -3183,20 +3228,27 @@ class NPUModelRunner(GPUModelRunner):
             if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
                 continue
             elif isinstance(kv_cache_spec, AttentionSpec):
-                # This is an attention backend that supports virtual
-                # block splitting. Get the supported block sizes from
-                # the backend.
-                
-                # This is an attention backend that supports virtual
-                # block splitting. Get the supported block sizes from
-                # all backends in the group.
+                # This is an attention backend that supports virtual block
+                # splitting. Select a common kernel block size from all
+                # backends in the KV cache group.
                 attn_groups = self.attn_groups[kv_cache_group_id]
                 kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
-                selected_kernel_size = select_common_block_size(
-                    kv_manager_block_size, [attn_group.backend for attn_group in attn_groups]
-                )
+                try:
+                    selected_kernel_size = select_common_block_size(
+                        kv_manager_block_size,
+                        [attn_group.backend for attn_group in attn_groups],
+                    )
+                except ValueError:
+                    # Hybrid groups may manage a smaller KV-cache block size
+                    # than the backend's default advertised kernel block size.
+                    # In that case, fall back to the group's block size.
+                    default_kernel_block_size = attn_groups[0].backend.get_supported_kernel_block_sizes()[0]
+                    if kv_manager_block_size < default_kernel_block_size:
+                        selected_kernel_size = kv_manager_block_size
+                    else:
+                        raise
                 self.kernel_block_sizes.append([selected_kernel_size])
-                
+
                 # try:
                 #     attn_groups = self.attn_groups[kv_cache_group_id]
                 # except IndexError:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR keeps the fix surface minimal and focused on the runtime compatibility
issues we actually hit after syncing with newer upstream `vllm` / `vllm-ascend`
code.

The committed changes cover three areas:

1. Selector signature compatibility
   - `vllm_ascend/patch/platform/patch_selector.py`
   - `patch_selector.get_attn_backend(...)` now accepts both the older
     Ascend-style `block_size` call pattern and the newer upstream-style
     signature, and also forwards `use_per_head_quant_scales` / `num_heads`.
   - If upstream does not pass `block_size`, the patch falls back to the
     user-specified cache block size when available.

2. Attention metadata compatibility in `NPUModelRunner`
   - `vllm_ascend/worker/model_runner_v1.py`
   - `NPUModelRunner._build_attn_metadata(...)` now only reads
     `prefill_ratio_to_sas_metadata` / `decode_ratio_to_sas_metadata` from
     `AscendDSAMetadataBuilder`, so normal builders no longer trip over missing
     attributes.
   - `NPUModelRunner._store_layer_attn_metadata(...)` keeps the upstream
     single-object path for normal models, but preserves the list-based path
     when `self.use_compress` is enabled for compressed multi-group models.
   - A `TODO(#57)` is left in place to track the later metadata-container
     refactor instead of expanding the scope of this PR.

3. Hybrid KV-cache kernel block-size consistency
   - `vllm_ascend/worker/model_runner_v1.py`
   - `vllm_ascend/attention/dsa_v1.py`
   - `AscendDSABackend.get_supported_kernel_block_sizes()` explicitly reports
     `[128]` to match the current backend contract.
   - `NPUModelRunner.may_reinitialize_input_batch(...)` now falls back to the
     KV-cache group's own `block_size` when `select_common_block_size(...)`
     cannot find a common value for hybrid `block_size=32` groups.
   - `NPUModelRunner._reshape_kv_cache_tensors(...)` now uses the selected
     group-level kernel block size from `self.kernel_block_sizes` instead of
     always reshaping with the backend's first advertised value. This keeps
     later KV-cache shaping consistent with the earlier selection result.

### Detailed change summary

- Runtime selector compatibility
  - `vllm_ascend/patch/platform/patch_selector.py`
  - `tests/ut/patch/platform/test_patch_selector.py`

- Attention metadata and hybrid KV-cache fixes
  - `vllm_ascend/worker/model_runner_v1.py`
  - `vllm_ascend/attention/dsa_v1.py`
  - `tests/ut/worker/test_model_runner_v1.py`

### Does this PR introduce _any_ user-facing change?

Yes, in terms of runtime compatibility and model bring-up stability:

- Qwen3 startup remains compatible with the current upstream selector path.
- GLM-related DSA metadata handling no longer depends on builder attributes
  that are absent on normal metadata builders.
- Hybrid `block_size=32` groups no longer select one kernel block size early
  and reshape KV cache later with a different one.
- Compressed multi-group models keep their required list-based per-layer
  metadata path, while normal models stay aligned with upstream single-metadata
  behavior.

There is no intended OpenAI API schema change.

### Effects / impact assessment

Expected positive effects:

- Better compatibility with newer upstream attention selector signatures.
- Lower risk of `AttributeError` during GLM / DSA metadata construction.
- Lower risk of KV-cache reshape mismatch in hybrid `block_size=32` setups.
- Safer handling of compressed multi-group attention metadata without changing
  the normal model path.

Behavioral notes:

- The backend contract still advertises kernel block size `128`; the hybrid
  `32` compatibility is handled in runner-side selection and reshape logic.
- The compressed-model metadata list path is intentionally gated by
  `self.use_compress` only, to avoid broadening behavior for unaffected models.

Non-goals / intentionally excluded:

- No extra refactor beyond the targeted runtime fixes.
- No smoke helper scripts, local task docs, or PR draft files are part of the
  commit.
- No Kimi follow-up in this PR.

### How was this patch tested?

Unit tests:

```bash
pytest -sv tests/ut/worker/test_model_runner_v1.py
pytest -sv tests/ut/patch/platform/test_patch_selector.py
```

Observed results:

- `tests/ut/worker/test_model_runner_v1.py`: `11 passed`
- `tests/ut/patch/platform/test_patch_selector.py`: `2 passed`

Manual smoke after rebasing onto the latest `v4_v0.18.0_0412`:

- `Qwen3-4B`
  - `/v1/models` returned `200`
  - `/v1/chat/completions` returned `200`
- `Qwen3.5-4B --max-model-len 2048 --max-num-seqs 4`
  - `/v1/models` returned `200`
  - `/v1/chat/completions` returned `200`
- `Qwen3.6-35B-A3B --tensor-parallel-size 4 --max-model-len 2048 --max-num-seqs 4 --gpu-memory-utilization 0.90`
  - `/v1/models` returned `200`
  - `/v1/chat/completions` returned `200`
- `GLM-5-w4a8 --tensor-parallel-size 16 --enable-expert-parallel --max-num-seqs 16 --max-model-len 32768 --trust-remote-code`
  - `/v1/models` returned `200`
  - `/v1/chat/completions` returned `200`

Smoke logs:

- `/tmp/qwen3_4b.20260418T071709Z.log`
- `/tmp/qwen3_5_4b_lowcap.20260418T071817Z.log`
- `/tmp/qwen3_6_35b_a3b_lowcap.20260418T071952Z.log`
- `/tmp/glm_5_w4a8.20260418T072220Z.log`

- vLLM version:
- vLLM main:
