### PR TITLE
fix(deepseek-v4): align compress metadata with config

### DIFF
--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -1,9 +1,12 @@
 import unittest
+from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import patch
 
 import torch
 
+import vllm_ascend.ops.fused_moe.moe_mlp as moe_mlp_mod
+from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
@@ -125,6 +128,130 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertTrue(quant_kwargs["dynamic_eplb"])
         self.assertFalse(quant_kwargs["use_bf16"])
         mock_unquant.assert_not_called()
+
+    def test_quant_apply_mlp_requires_swiglu_limit_for_fused_gmm_path(self):
+        hidden_states = torch.randn(2, 8)
+        scale = torch.randn(2, 1)
+        group_list = torch.tensor([2], dtype=torch.int64)
+
+        for comm_type in (MoECommType.MC2, None):
+            with self.subTest(comm_type=comm_type):
+                with (
+                    patch.object(
+                        type(moe_mlp_mod._EXTRA_CTX),
+                        "_ctx",
+                        return_value=SimpleNamespace(moe_comm_type=comm_type),
+                    ),
+                    patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method", return_value=None),
+                    patch.object(
+                        torch.ops._C_ascend,
+                        "grouped_matmul_swiglu_quant_weight_nz",
+                        return_value=(hidden_states, scale, None),
+                        create=True,
+                    ) as mock_grouped_matmul,
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "swiglu_limit must be set for grouped_matmul_swiglu_quant_weight_nz",
+                    ):
+                        moe_mlp_mod.quant_apply_mlp(
+                            hidden_states=hidden_states,
+                            w1=torch.randn(16, 8),
+                            w1_scale=torch.randn(1),
+                            w2=torch.randn(8, 8),
+                            w2_scale=torch.randn(1),
+                            group_list=group_list,
+                            dynamic_scale=scale,
+                            fusion=True,
+                        )
+                mock_grouped_matmul.assert_not_called()
+
+    def test_quant_apply_mlp_forwards_swiglu_limit_to_fused_gmm_path(self):
+        hidden_states = torch.randn(2, 8)
+        scale = torch.randn(2, 1)
+        group_list = torch.tensor([2], dtype=torch.int64)
+        expected = torch.randn(2, 8)
+
+        for comm_type in (MoECommType.MC2, None):
+            with self.subTest(comm_type=comm_type):
+                with (
+                    patch.object(
+                        type(moe_mlp_mod._EXTRA_CTX),
+                        "_ctx",
+                        return_value=SimpleNamespace(moe_comm_type=comm_type),
+                    ),
+                    patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method", return_value=None),
+                    patch("vllm_ascend.ops.fused_moe.moe_mlp.dispose_tensor"),
+                    patch(
+                        "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                        return_value=expected,
+                    ),
+                    patch.object(
+                        torch.ops._C_ascend,
+                        "grouped_matmul_swiglu_quant_weight_nz",
+                        return_value=(hidden_states, scale, None),
+                        create=True,
+                    ) as mock_grouped_matmul,
+                ):
+                    output = moe_mlp_mod.quant_apply_mlp(
+                        hidden_states=hidden_states,
+                        w1=torch.randn(16, 8),
+                        w1_scale=torch.randn(1),
+                        w2=torch.randn(8, 8),
+                        w2_scale=torch.randn(1),
+                        group_list=group_list,
+                        dynamic_scale=scale,
+                        fusion=True,
+                        swiglu_limit=12.5,
+                    )
+
+                self.assertTrue(output is expected)
+                mock_grouped_matmul.assert_called_once()
+                self.assertEqual(mock_grouped_matmul.call_args.kwargs["swiglu_limit"], 12.5)
+
+    def test_quant_apply_mlp_does_not_forward_swiglu_limit_to_tensor_list_path(self):
+        hidden_states = torch.randn(2, 8)
+        scale = torch.randn(2, 1)
+        group_list = torch.tensor([2], dtype=torch.int64)
+        expected = torch.randn(2, 8)
+
+        for comm_type in (MoECommType.MC2, None):
+            with self.subTest(comm_type=comm_type):
+                with (
+                    patch.object(
+                        type(moe_mlp_mod._EXTRA_CTX),
+                        "_ctx",
+                        return_value=SimpleNamespace(moe_comm_type=comm_type),
+                    ),
+                    patch("vllm_ascend.ops.fused_moe.moe_mlp.enable_custom_op", return_value=True),
+                    patch("vllm_ascend.ops.fused_moe.moe_mlp.get_weight_prefetch_method", return_value=None),
+                    patch(
+                        "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                        return_value=expected,
+                    ),
+                    patch.object(
+                        torch.ops._C_ascend,
+                        "grouped_matmul_swiglu_quant_weight_nz_tensor_list",
+                        return_value=(hidden_states, scale, None),
+                        create=True,
+                    ) as mock_tensor_list,
+                ):
+                    output = moe_mlp_mod.quant_apply_mlp(
+                        hidden_states=hidden_states,
+                        w1=[torch.randn(16, 8)],
+                        w1_scale=[torch.randn(1)],
+                        w2=[torch.randn(8, 8)],
+                        w2_scale=[torch.randn(1)],
+                        group_list=group_list,
+                        dynamic_scale=scale,
+                        fusion=True,
+                        dynamic_eplb=True,
+                        swiglu_limit=12.5,
+                    )
+
+                self.assertTrue(output is expected)
+                mock_tensor_list.assert_called_once()
+                self.assertNotIn("swiglu_limit", mock_tensor_list.call_args.kwargs)
 
 
 if __name__ == "__main__":

--- a/tests/ut/transformers_utils/test_deepseek_v4_config.py
+++ b/tests/ut/transformers_utils/test_deepseek_v4_config.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from vllm_ascend.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
+
+
+def _write_config(tmp_path, **overrides):
+    config = {
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 4,
+        "compress_ratios": [1, 1, 4, 128],
+        "rope_theta": 12345,
+        "compress_rope_theta": 67890,
+        "swiglu_limit": 12.5,
+        "rope_scaling": {
+            "type": "yarn",
+            "factor": 16,
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "original_max_position_embeddings": 65536,
+        },
+    }
+    config.update(overrides)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    return config_path
+
+
+def test_missing_compress_ratios_defaults_to_uncompressed_layers():
+    config = DeepseekV4Config(swiglu_limit=10.0)
+
+    assert config.compress_ratios == [0] * config.num_hidden_layers
+    assert config.rope_theta == 10000.0
+    assert config.compress_rope_theta == 160000.0
+    assert config.get_layer_compress_ratio(0) == 1
+    assert config.get_layer_rope_theta(0) == 10000.0
+
+
+def test_compress_parameters_are_loaded_from_metadata(tmp_path):
+    _write_config(tmp_path, compress_ratios=[0, 1, 4, 128])
+
+    config = DeepseekV4Config.from_pretrained(tmp_path)
+
+    assert config.compress_ratios == [0, 1, 4, 128]
+    assert config.get_layer_compress_ratio(0) == 1
+    assert config.get_layer_compress_ratio(1) == 1
+    assert config.get_layer_compress_ratio(3) == 128
+    assert config.get_layer_rope_theta(0) == 12345
+    assert config.get_layer_rope_theta(1) == 12345
+    assert config.get_layer_rope_theta(2) == 67890
+    assert config.get_layer_rope_theta(3) == 67890
+    assert config.swiglu_limit == 12.5
+    assert config.get_rope_groups_for_compress_ratio(0) == ["default"]
+    assert config.get_rope_groups_for_compress_ratio(1) == ["default"]
+    assert config.get_rope_groups_for_compress_ratio(4) == ["default", "c4"]
+    assert config.get_rope_groups_for_compress_ratio(128) == ["default", "c128"]
+
+
+def test_invalid_compress_ratio_is_rejected(tmp_path):
+    _write_config(tmp_path, compress_ratios=[1, 7, 4, 128])
+
+    with pytest.raises(ValueError, match="compress_ratios contains unsupported values"):
+        DeepseekV4Config.from_pretrained(tmp_path)
+
+
+def test_short_compress_ratio_list_is_padded_with_zero(tmp_path):
+    _write_config(tmp_path, compress_ratios=[1, 4, 128])
+
+    with pytest.warns(UserWarning, match="remaining layers will be padded with 0"):
+        config = DeepseekV4Config.from_pretrained(tmp_path)
+
+    assert config.compress_ratios == [1, 4, 128, 0]
+    assert config.mtp_compress_ratios == []
+    assert config.get_layer_compress_ratio(3) == 1
+    assert config.get_layer_rope_theta(3) == 12345
+
+
+def test_long_compress_ratio_list_preserves_mtp_entries(tmp_path):
+    _write_config(tmp_path, compress_ratios=[1, 4, 128, 0, 4, 128])
+
+    with pytest.warns(UserWarning, match="preserved as mtp_compress_ratios"):
+        config = DeepseekV4Config.from_pretrained(tmp_path)
+
+    assert config.compress_ratios == [1, 4, 128, 0, 4, 128]
+    assert config.mtp_compress_ratios == [4, 128]

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -330,6 +330,7 @@ class DeepseekV4MoE(nn.Module):
             if self.is_fusion_moe_shared_experts_enabled else 0,
             hash=layer_idx < config.n_hash_layers and not is_draft_layer,
             tid2eid=self.gate.tid2eid)
+        self.experts.swiglu_limit = config.swiglu_limit
 
     def forward(self,
                 hidden_states: torch.Tensor,
@@ -629,14 +630,12 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{prefix}.wo_b",
             return_bias=False,
         )
-        self.compress_ratio = config.compress_ratios[layer_idx]
-
-        if self.compress_ratio > 1:
-            config.rope_parameters['rope_theta'] = 160000
-            rope_groups = ['default', f'c{self.compress_ratio}']
-        else:
-            config.rope_parameters['rope_theta'] = 10000
-            rope_groups = ['default']
+        self.compress_ratio = config.get_layer_compress_ratio(layer_idx)
+        rope_theta = config.get_rope_theta_for_compress_ratio(
+            self.compress_ratio)
+        config.rope_parameters['rope_theta'] = rope_theta
+        rope_groups = config.get_rope_groups_for_compress_ratio(
+            self.compress_ratio)
         self.rotary_emb = ComplexExpRotaryEmbedding(
             vllm_config=vllm_config,
             layername=f'{prefix}.attn',
@@ -645,7 +644,7 @@ class DeepseekV4Attention(nn.Module):
             max_position_embeddings=max_position_embeddings,
             is_neox_style=False,
             scaling_factor=config.rope_parameters['factor'],
-            base=config.rope_parameters['rope_theta'],
+            base=rope_theta,
             beta_fast=config.rope_parameters['beta_fast'],
             beta_slow=config.rope_parameters['beta_slow'],
             rope_groups=rope_groups)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -101,6 +101,7 @@ def quant_apply_mlp(
     scale_type: torch.dtype | None = None,
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
+    swiglu_limit: float | None = None,
 ) -> torch.Tensor:
     input_hidden_dtype = hidden_states.dtype
     use_gmm_swiglu_quant_fusion = use_mxfp_quant or (fusion and not dynamic_eplb)
@@ -161,6 +162,8 @@ def quant_apply_mlp(
             #     bias=None,
             #     use_mxfp_quant=use_mxfp_quant,
             # )
+            if swiglu_limit is None:
+                raise ValueError("swiglu_limit must be set for grouped_matmul_swiglu_quant_weight_nz.")
             hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz(
                 x=hidden_states,
                 weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
@@ -168,7 +171,7 @@ def quant_apply_mlp(
                 weight_scale=_require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale"),
                 x_scale=pertoken_scale,
                 bias=None,
-                swiglu_limit=10
+                swiglu_limit=swiglu_limit,
             )
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
@@ -275,6 +278,8 @@ def quant_apply_mlp(
             #     bias=bias1,
             #     use_mxfp_quant=use_mxfp_quant,
             # )
+            if swiglu_limit is None:
+                raise ValueError("swiglu_limit must be set for grouped_matmul_swiglu_quant_weight_nz.")
             hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz(
                 x=hidden_states,
                 weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
@@ -282,7 +287,7 @@ def quant_apply_mlp(
                 weight_scale=_require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale"),
                 x_scale=pertoken_scale,
                 bias=bias1,
-                swiglu_limit=10.0
+                swiglu_limit=swiglu_limit,
             )
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
@@ -458,4 +463,5 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         scale_type=scale_type,
         per_token_scale_type=per_token_scale_type,
         use_bf16=use_bf16,
+        swiglu_limit=mlp_compute_input.swiglu_limit,
     )

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -144,6 +144,7 @@ def build_fused_experts_input(
     w2_scale_bias: torch.Tensor | None = None,
     w1_offset: torch.Tensor | None = None,
     w2_offset: torch.Tensor | None = None,
+    swiglu_limit: float | None = None,
 ) -> MoEFusedExpertsInput:
     return MoEFusedExpertsInput(
         hidden_states=hidden_states,
@@ -172,6 +173,7 @@ def build_fused_experts_input(
         activation=activation,
         need_trans=need_trans,
         dynamic_eplb=dynamic_eplb,
+        swiglu_limit=swiglu_limit,
         quant=MoEQuantParams(
             quant_type=quant_type,
             comm_quant_mode=comm_quant_mode,
@@ -222,6 +224,7 @@ def build_mlp_compute_input(
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,
+        swiglu_limit=fused_experts_input.swiglu_limit,
     )
 
 

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -68,6 +68,7 @@ class MoEFusedExpertsInput:
     activation: str = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
+    swiglu_limit: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,6 +140,7 @@ class MoEMlpComputeInput:
     activation: str = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False
+    swiglu_limit: float | None = None
 
 
 __all__ = [

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -271,6 +271,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 activation=activation,
                 w1_scale=w1_scale,
                 w2_scale=w2_scale,
+                swiglu_limit=getattr(layer, "swiglu_limit", None),
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:

--- a/vllm_ascend/transformers_utils/configs/deepseek_v4.py
+++ b/vllm_ascend/transformers_utils/configs/deepseek_v4.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import warnings
+
 from transformers import PretrainedConfig
 from transformers.modeling_rope_utils import rope_config_validation
+
+
+SUPPORTED_COMPRESS_RATIOS = frozenset({0, 1, 4, 128})
 
 
 class DeepseekV4Config(PretrainedConfig):
@@ -135,6 +140,48 @@ class DeepseekV4Config(PretrainedConfig):
         "norm": (["hidden_states"], ["hidden_states"]),
     }
 
+    @staticmethod
+    def _normalize_compress_ratios(
+        compress_ratios: list[int] | None,
+        num_hidden_layers: int,
+    ) -> list[int]:
+        normalized = [] if compress_ratios is None else list(compress_ratios)
+
+        if compress_ratios is not None and len(normalized) < num_hidden_layers:
+            warnings.warn(
+                "compress_ratios provides fewer entries than num_hidden_layers; "
+                f"got {len(normalized)} values for {num_hidden_layers} hidden "
+                "layers. The remaining layers will be padded with 0.",
+                stacklevel=2,
+            )
+        if len(normalized) < num_hidden_layers:
+            normalized.extend([0] * (num_hidden_layers - len(normalized)))
+        elif len(normalized) > num_hidden_layers:
+            extra_count = len(normalized) - num_hidden_layers
+            warnings.warn(
+                "compress_ratios provides more entries than num_hidden_layers; "
+                f"got {len(normalized)} values for {num_hidden_layers} hidden "
+                "layers. The trailing "
+                f"{extra_count} value(s) will be preserved as "
+                "mtp_compress_ratios. TODO: MTP compress is not implemented "
+                "yet.",
+                stacklevel=2,
+            )
+
+        invalid_ratios = sorted(set(normalized) - SUPPORTED_COMPRESS_RATIOS)
+        if invalid_ratios:
+            raise ValueError(
+                "compress_ratios contains unsupported values "
+                f"{invalid_ratios}. Supported values are "
+                f"{sorted(SUPPORTED_COMPRESS_RATIOS)}."
+            )
+
+        return normalized
+
+    @staticmethod
+    def _to_runtime_compress_ratio(compress_ratio: int) -> int:
+        return 1 if compress_ratio == 0 else compress_ratio
+
     def __init__(
         self,
         # base
@@ -162,13 +209,10 @@ class DeepseekV4Config(PretrainedConfig):
         o_groups=8,
         o_lora_rank=1024,
         window_size=128,
-        compress_ratios=[
-            1, 1, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
-            128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
-            128, 4, 128, 4, 128, 4, 128, 4, 128, 4
-        ],
+        compress_ratios=None,
+        swiglu_limit=None,
         # yarn
-        compress_rope_theta=40000,
+        compress_rope_theta=160000.0,
         # original_seq_len=65536,
         # rope_theta=10000,
         # rope_factor=4,
@@ -227,7 +271,9 @@ class DeepseekV4Config(PretrainedConfig):
         self.o_groups = o_groups
         self.o_lora_rank = o_lora_rank
         self.window_size = window_size
-        self.compress_ratios = [1, 1, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4]
+        self.compress_ratios = self._normalize_compress_ratios(
+            compress_ratios, self.num_hidden_layers)
+        self.swiglu_limit = swiglu_limit
         # NOTE: This is only for making is_deepseek_mla is True
         self.kv_lora_rank = o_lora_rank
 
@@ -277,3 +323,23 @@ class DeepseekV4Config(PretrainedConfig):
             tie_word_embeddings=tie_word_embeddings,
             **kwargs,
         )
+
+    @property
+    def mtp_compress_ratios(self) -> list[int]:
+        # TODO: Wire MTP compress ratios into the draft-layer runtime once
+        # DeepSeek-V4 MTP compress support is implemented.
+        return self.compress_ratios[self.num_hidden_layers:]
+
+    def get_layer_compress_ratio(self, layer_idx: int) -> int:
+        return self._to_runtime_compress_ratio(self.compress_ratios[layer_idx])
+
+    def get_rope_theta_for_compress_ratio(self, compress_ratio: int) -> float:
+        return self.compress_rope_theta if compress_ratio > 1 else self.rope_theta
+
+    def get_layer_rope_theta(self, layer_idx: int) -> float:
+        return self.get_rope_theta_for_compress_ratio(self.get_layer_compress_ratio(layer_idx))
+
+    def get_rope_groups_for_compress_ratio(self, compress_ratio: int) -> list[str]:
+        if compress_ratio > 1:
+            return ["default", f"c{compress_ratio}"]
+        return ["default"]


### PR DESCRIPTION
- load DeepseekV4 compress metadata from config.json instead of hard-coded values
- treat compress_ratios 0 and 1 as uncompressed while preserving trailing MTP metadata entries with warnings
- read swiglu_limit from model metadata and wire it through the required w8a8 fused MoE path

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
