### PR TITLE
[Bugfix][Worker] Restore hybrid KV and draft slot mapping stability

### DIFF
--- a/tests/ut/patch/platform/test_patch_selector.py
+++ b/tests/ut/patch/platform/test_patch_selector.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from vllm_ascend.patch.platform import patch_selector
+
+
+def test_get_attn_backend_supports_legacy_block_size_argument():
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            user_specified_block_size=False,
+            block_size=256,
+        ),
+        attention_config=SimpleNamespace(backend="ascend"),
+    )
+
+    with patch("vllm.config.get_current_vllm_config", return_value=vllm_config):
+        with patch(
+            "vllm_ascend.patch.platform.patch_selector._cached_get_attn_backend",
+            return_value="backend",
+        ) as mock_cached:
+            result = patch_selector.get_attn_backend(
+                0,
+                torch.bfloat16,
+                None,
+                128,
+                use_mla=True,
+                use_sparse=True,
+                use_compress=True,
+            )
+
+    assert result == "backend"
+    selector_config = mock_cached.call_args.kwargs["attn_selector_config"]
+    assert selector_config.block_size == 128
+    assert selector_config.use_mla is True
+    assert selector_config.use_sparse is True
+    assert selector_config.use_compress is True
+
+
+def test_get_attn_backend_uses_user_block_size_for_new_signature_calls():
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            user_specified_block_size=True,
+            block_size=64,
+        ),
+        attention_config=SimpleNamespace(backend="ascend"),
+    )
+
+    with patch("vllm.config.get_current_vllm_config", return_value=vllm_config):
+        with patch(
+            "vllm_ascend.patch.platform.patch_selector._cached_get_attn_backend",
+            return_value="backend",
+        ) as mock_cached:
+            result = patch_selector.get_attn_backend(
+                0,
+                torch.bfloat16,
+                None,
+                use_mla=False,
+                use_sparse=False,
+                use_per_head_quant_scales=True,
+                num_heads=32,
+            )
+
+    assert result == "backend"
+    selector_config = mock_cached.call_args.kwargs["attn_selector_config"]
+    assert selector_config.block_size == 64
+    assert selector_config.use_per_head_quant_scales is True
+    assert mock_cached.call_args.kwargs["num_heads"] == 32

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import unittest
 
@@ -486,3 +488,148 @@ class TestEagleProposerHelperMethods(TestBase):
         ):
             return_attn, indices = self.proposer.prepare_inputs(mock_attn, num_rejected)
             self.assertEqual(indices.tolist(), [1, 2, 4])
+
+    def test_set_inputs_first_pass_uses_kernel_block_size(self):
+        metadata_builder = MagicMock()
+        metadata_builder.kv_cache_spec.block_size = 32
+        draft_attn_group = MagicMock()
+        draft_attn_group.get_metadata_builder.return_value = metadata_builder
+        draft_attn_group.kv_cache_spec.block_size = 128
+        self.proposer.draft_attn_groups = [draft_attn_group]
+        self.proposer.kernel_block_size = 128
+        self.proposer.needs_extra_input_slots = True
+        self.proposer.pass_hidden_states_to_model = False
+        self.proposer.parallel_drafting_token_id = 0
+        self.proposer.extra_slots_per_request = 1
+        self.proposer.net_num_new_slots_per_request = 1
+
+        cad = MagicMock()
+        cad.query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+        cad.batch_size.return_value = 2
+
+        target_token_ids = torch.tensor([11, 12], dtype=torch.int32)
+        next_token_ids = torch.tensor([21, 22], dtype=torch.int32)
+        target_positions = torch.tensor([0, 1], dtype=torch.int32)
+        target_hidden_states = torch.zeros((2, self.proposer.hidden_size), dtype=self.vllm_config.model_config.dtype)
+
+        total_num_output_tokens = target_token_ids.shape[0] + cad.batch_size() * self.proposer.net_num_new_slots_per_request
+        copy_and_expand_outputs = (
+            torch.zeros(total_num_output_tokens, dtype=torch.int32),
+            torch.arange(total_num_output_tokens, dtype=torch.int32),
+            torch.zeros(total_num_output_tokens, dtype=torch.bool),
+            torch.zeros(total_num_output_tokens, dtype=torch.bool),
+            torch.tensor([0, 2], dtype=torch.int32),
+            torch.zeros(target_token_ids.shape[0], dtype=torch.int64),
+        )
+
+        with (
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_copy_and_expand_eagle_inputs",
+                create=True,
+                return_value=copy_and_expand_outputs,
+            ),
+            patch(
+                "vllm_ascend.spec_decode.eagle_proposer.compute_new_slot_mapping",
+                return_value=torch.zeros(total_num_output_tokens, dtype=torch.int32),
+            ) as mock_compute_new_slot_mapping,
+            patch(
+                "vllm_ascend.spec_decode.eagle_proposer.extend_all_queries_by_N",
+                return_value=MagicMock(),
+            ),
+        ):
+            self.proposer.set_inputs_first_pass(
+                target_token_ids=target_token_ids,
+                next_token_ids=next_token_ids,
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                token_indices_to_sample=None,
+                cad=cad,
+                num_rejected_tokens_gpu=None,
+            )
+
+        self.assertEqual(mock_compute_new_slot_mapping.call_args.kwargs["block_size"], 128)
+
+    def test_propose_omits_dsa_kwargs_for_non_dsa_builder(self):
+        builder = MagicMock()
+        builder.build.return_value = SimpleNamespace(num_prefills=0)
+        draft_attn_group = MagicMock()
+        draft_attn_group.get_metadata_builder.return_value = builder
+        self.proposer.draft_attn_groups = [draft_attn_group]
+        self.proposer.attn_layer_names = ["layer0"]
+        self.proposer.num_speculative_tokens = 1
+        self.proposer.use_cuda_graph = False
+        self.proposer.supports_mm_inputs = False
+        self.proposer.parallel_drafting = False
+        self.proposer.positions = torch.zeros(4, dtype=torch.int32)
+        self.proposer.slot_mapping_group = [torch.full((4,), -1, dtype=torch.int32)]
+        self.proposer.token_indices_to_sample = torch.zeros(4, dtype=torch.int32)
+        self.proposer._runnable = MagicMock(return_value=torch.zeros((1, 1), dtype=torch.int64))
+        self.runner.get_model.return_value = MagicMock()
+        self.runner._sync_metadata_across_dp.return_value = (1, 1, None)
+        self.runner.input_batch.lora_id_to_lora_request = {}
+
+        common_attn_metadata = SimpleNamespace(
+            batch_size=lambda: 1,
+            slot_mapping=torch.tensor([0], dtype=torch.int32),
+            block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+            num_reqs=1,
+        )
+
+        with (
+            patch.object(
+                self.proposer,
+                "set_inputs_first_pass",
+                return_value=(1, torch.tensor([0], dtype=torch.int32), common_attn_metadata, None),
+            ),
+            patch("vllm_ascend.spec_decode.eagle_proposer.set_ascend_forward_context", return_value=nullcontext()),
+            patch(
+                "vllm_ascend.spec_decode.eagle_proposer.get_forward_context",
+                return_value=SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE, moe_layer_index=0),
+            ),
+        ):
+            self.proposer._propose(
+                target_token_ids=torch.tensor([11], dtype=torch.int32),
+                target_positions=torch.tensor([0], dtype=torch.int32),
+                target_hidden_states=torch.zeros((1, self.proposer.hidden_size), dtype=self.vllm_config.model_config.dtype),
+                next_token_ids=torch.tensor([21], dtype=torch.int32),
+                token_indices_to_sample=torch.tensor([0], dtype=torch.int32),
+                common_attn_metadata=common_attn_metadata,
+                target_model_batch_desc=SimpleNamespace(uniform=False),
+                sampling_metadata=MagicMock(),
+            )
+
+        self.assertEqual(builder.build.call_args.kwargs, {})
+
+    def test_attn_update_stack_num_spec_norm_omits_dsa_kwargs_for_non_dsa_builder(self):
+        builder = MagicMock()
+        builder.build.return_value = SimpleNamespace(decode=None)
+        attn_group = MagicMock()
+        attn_group.get_metadata_builder.return_value = builder
+        self.proposer.kernel_block_size = 128
+        self.proposer.slot_mapping_group = [
+            torch.full((4,), -1, dtype=torch.int32),
+            torch.full((4,), -1, dtype=torch.int32),
+        ]
+        self.runner.get_model.return_value = MagicMock()
+
+        old_common_attn_metadata = SimpleNamespace(
+            block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([1], dtype=torch.int32),
+            num_computed_tokens_cpu=torch.tensor([0], dtype=torch.int32),
+            positions=torch.tensor([0], dtype=torch.int32),
+        )
+
+        self.proposer.attn_update_stack_num_spec_norm(
+            draft_step=1,
+            old_attn_metadata=MagicMock(),
+            old_common_metadata=old_common_attn_metadata,
+            batch_size=1,
+            input_batch_size=1,
+            used_update_positions=torch.tensor([0], dtype=torch.int32),
+            aclgraph_runtime_mode=CUDAGraphMode.NONE,
+            attn_group=attn_group,
+        )
+
+        self.assertEqual(builder.build.call_args.kwargs, {})

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -1,10 +1,12 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
+from vllm_ascend.core.kv_cache_spec import C4IndexerSpec
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
@@ -15,14 +17,29 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.device = torch.device("cpu")
         runner.use_sparse = False
         runner.use_sparse_c8_indexer = False
+        runner.use_compress = False
         runner.use_hybrid_blocks = False
         runner.hybrid_with_attn_and_mamba = False
         runner.runner_only_attn_layers = set()
         runner.is_kv_consumer = False
         runner.vllm_config = MagicMock()
         runner.vllm_config.kv_transfer_config = None
+        runner.vllm_config.speculative_config = None
         runner.model_config = MagicMock()
         runner.model_config.use_mla = True
+        runner.model_config.get_vocab_size.return_value = 32000
+        runner.block_size = 128
+        runner.cache_config = SimpleNamespace(block_size=128)
+        runner.offload_config = SimpleNamespace(
+            uva=SimpleNamespace(cpu_offload_gb=0),
+        )
+        runner.max_num_reqs = 8
+        runner.max_model_len = 128
+        runner.max_encoder_len = 0
+        runner.max_num_tokens = 128
+        runner.pin_memory = False
+        runner.is_pooling_model = False
+        runner.input_batch = SimpleNamespace(logitsprocs=[])
         backend = MagicMock()
         backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
             2,
@@ -84,6 +101,170 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
 
+    def test_reshape_kv_cache_uses_selected_kernel_block_size_for_hybrid_group(self):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        runner.kernel_block_sizes = [[32]]
+        runner.attn_backend.get_supported_kernel_block_sizes.return_value = [128, 32]
+
+        kv_cache_spec = FullAttentionSpec(
+            block_size=32,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[KVCacheTensor(size=kv_cache_spec.page_size_bytes * 2, shared_by=["draft_attn"])],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=["draft_attn"],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+        kv_cache_raw_tensors = runner._allocate_kv_cache_tensors(kv_cache_config)
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_group_id=0,
+                kv_cache_spec=kv_cache_spec,
+                backend=runner.attn_backend,
+                layer_names=["draft_attn"],
+            )
+        ]
+
+        kv_caches = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            kv_cache_raw_tensors,
+        )
+        k_cache, v_cache = kv_caches["draft_attn"]
+
+        self.assertEqual(k_cache.shape, (2, 32, 8, 64))
+        self.assertEqual(v_cache.shape, (2, 32, 8, 64))
+        runner.attn_backend.get_kv_cache_shape.assert_any_call(2, 32, 8, 64)
+
+    def test_reshape_kv_cache_keeps_physical_block_size_for_compressed_c4_indexer_group(self):
+        runner = self._build_runner()
+        runner.use_compress = True
+        runner.use_hybrid_blocks = True
+        runner.kernel_block_sizes = [[128]]
+        runner.attn_backend = MagicMock()
+        runner.attn_backend.get_supported_kernel_block_sizes.return_value = [128]
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+
+        kv_cache_spec = C4IndexerSpec(
+            block_size=1024,
+            num_kv_heads=1,
+            head_size=128,
+            indexer_scale_dim=1,
+            dtype=torch.int8,
+            page_size_padded=0,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=kv_cache_spec.page_size_bytes * 2,
+                    shared_by=["draft_attn"],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=["draft_attn"],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+        kv_cache_raw_tensors = runner._allocate_kv_cache_tensors(kv_cache_config)
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_group_id=0,
+                kv_cache_spec=kv_cache_spec,
+                backend=runner.attn_backend,
+                layer_names=["draft_attn"],
+            )
+        ]
+
+        kv_caches = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            kv_cache_raw_tensors,
+        )
+        indexer_k_cache, indexer_scale_cache = kv_caches["draft_attn"]
+
+        self.assertEqual(indexer_k_cache.shape, (2, 1024, 1, 128))
+        self.assertEqual(indexer_scale_cache.shape, (2, 1024, 1, 1))
+        runner.attn_backend.get_kv_cache_shape.assert_any_call(2, 1024, 1, 128)
+        runner.attn_backend.get_kv_cache_shape.assert_any_call(2, 1024, 1, 1)
+
+    def test_may_reinitialize_input_batch_uses_backend_supported_sizes_for_normal_model(self):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        backend = MagicMock()
+        backend.get_supported_kernel_block_sizes.return_value = [128]
+        runner.attn_groups = [[SimpleNamespace(backend=backend)]]
+        kv_cache_spec = FullAttentionSpec(
+            block_size=32,
+            num_kv_heads=8,
+            head_size=64,
+            head_size_v=64,
+            dtype=torch.float16,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=["draft_attn"],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+
+        with patch(
+            "vllm_ascend.worker.model_runner_v1.select_common_block_size",
+        ) as mock_select_common_block_size:
+            with patch("vllm_ascend.worker.model_runner_v1.NPUInputBatch") as mock_input_batch:
+                runner.may_reinitialize_input_batch(kv_cache_config)
+
+        mock_select_common_block_size.assert_not_called()
+        self.assertEqual(runner.kernel_block_sizes, [[128]])
+        self.assertEqual(
+            mock_input_batch.call_args.kwargs["kernel_block_sizes"],
+            [[128]],
+        )
+
+    def test_initialize_kv_cache_passes_first_kernel_block_size_group_to_drafter(self):
+        runner = self._build_runner()
+        runner.attn_groups = [[SimpleNamespace(kv_cache_spec=object())]]
+        runner.kernel_block_sizes = [[128], [32], [0]]
+        runner.speculative_config = MagicMock()
+        runner.speculative_config.use_eagle.return_value = True
+        runner.speculative_config.uses_draft_model.return_value = False
+        runner.drafter = AscendEagleProposer.__new__(AscendEagleProposer)
+        runner.drafter.initialize_attn_backend = MagicMock()
+        runner.initialize_attn_backend = MagicMock()
+        runner.may_add_encoder_only_layers_to_kv_cache_config = MagicMock()
+        runner.maybe_add_kv_sharing_layers_to_kv_cache_groups = MagicMock()
+        runner.may_reinitialize_input_batch = MagicMock()
+        runner.initialize_kv_cache_tensors = MagicMock(return_value={})
+        runner.model_config.enable_return_routed_experts = False
+        kv_cache_config = SimpleNamespace(kv_cache_groups=[])
+
+        with patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False):
+            runner.initialize_kv_cache(kv_cache_config)
+
+        self.assertEqual(
+            runner.drafter.initialize_attn_backend.call_args.args[1],
+            [128],
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/vllm_ascend/patch/platform/patch_selector.py
+++ b/vllm_ascend/patch/platform/patch_selector.py
@@ -6,6 +6,7 @@ from vllm.config.cache import CacheDType
 from vllm.v1.attention.backend import AttentionBackend, AttentionType
 from vllm.v1.attention.selector import _cached_get_attn_backend
 
+
 class AttentionSelectorConfig(NamedTuple):
     head_size: int
     dtype: torch.dtype
@@ -16,6 +17,7 @@ class AttentionSelectorConfig(NamedTuple):
     use_compress: bool = False
     use_sparse: bool = False
     use_mm_prefix: bool = False
+    use_per_head_quant_scales: bool = False
     attn_type: str = AttentionType.DECODER
 
     def __repr__(self):
@@ -28,6 +30,7 @@ class AttentionSelectorConfig(NamedTuple):
                 f"use_compress={self.use_compress}, "
                 f"use_sparse={self.use_sparse}, "
                 f"use_mm_prefix={self.use_mm_prefix}, "
+                f"use_per_head_quant_scales={self.use_per_head_quant_scales}, "
                 f"attn_type={self.attn_type})")
 
 
@@ -35,13 +38,15 @@ def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
     kv_cache_dtype: str | None,
-    block_size: int | None,
+    block_size: int | None = None,
     use_mla: bool = False,
     has_sink: bool = False,
     use_compress: bool = False,
     use_sparse: bool = False,
     use_mm_prefix: bool = False,
+    use_per_head_quant_scales: bool = False,
     attn_type: str | None = None,
+    num_heads: int | None = None,
 ) -> type[AttentionBackend]:
     """Selects which attention backend to use and lazily imports it."""
 
@@ -55,6 +60,9 @@ def get_attn_backend(
 
     vllm_config = get_current_vllm_config()
     backend_enum = vllm_config.attention_config.backend
+    cache_config = vllm_config.cache_config
+    if block_size is None and cache_config is not None and cache_config.user_specified_block_size:
+        block_size = cache_config.block_size
 
     attn_selector_config = AttentionSelectorConfig(
         head_size=head_size,
@@ -66,12 +74,14 @@ def get_attn_backend(
         use_compress=use_compress,
         use_sparse=use_sparse,
         use_mm_prefix=use_mm_prefix,
+        use_per_head_quant_scales=use_per_head_quant_scales,
         attn_type=attn_type or AttentionType.DECODER,
     )
 
     return _cached_get_attn_backend(
         backend=backend_enum,
         attn_selector_config=attn_selector_config,
+        num_heads=num_heads,
     )
 
 

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -42,6 +42,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
@@ -580,10 +581,12 @@ class SpecDecodeBaseProposer(EagleProposer):
         # FIXME(woosuk): The below two ops cause synchronization. Optimize.
         assert len(self.draft_attn_groups) > 0
         builder = self.draft_attn_groups[0].get_metadata_builder()
-        extra_attn_metadata_args = dict(
-                    prefill_ratio_to_sas_metadata=dict(),
-                    decode_ratio_to_sas_metadata=dict(),
-                    common_ratio_to_sas_metadata=dict())
+        extra_attn_metadata_args = {}
+        if isinstance(builder, AscendDSAMetadataBuilder):
+            extra_attn_metadata_args = dict(
+                        prefill_ratio_to_sas_metadata=dict(),
+                        decode_ratio_to_sas_metadata=dict(),
+                        common_ratio_to_sas_metadata=dict())
         attn_metadata = builder.build(0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args)
 
         if self.uses_mrope:
@@ -1091,10 +1094,12 @@ class SpecDecodeBaseProposer(EagleProposer):
             # 2.
             # Recompute the slot mapping based on the new positions and
             # rejection mask.
-            # Use the first draft attention group's kv_cache_spec for block_size
-            # (all draft layers share the same kv-cache group)
-            assert len(self.draft_attn_groups) > 0
-            block_size = self.draft_attn_groups[0].kv_cache_spec.block_size
+            # Use the draft kernel block size rather than the physical
+            # KV-cache block size. Hybrid/compressed groups can expose a
+            # larger physical block size than the slot_mapping expects.
+            block_size = self.kernel_block_size
+            if not isinstance(block_size, int):
+                block_size = 128
 
             new_slot_mapping = compute_new_slot_mapping(
                 cad=cad,
@@ -1258,10 +1263,12 @@ class SpecDecodeBaseProposer(EagleProposer):
             common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
 
         attn_metadata_builder = attn_group.get_metadata_builder()
-        extra_attn_metadata_args = dict(
-                    prefill_ratio_to_sas_metadata=dict(),
-                    decode_ratio_to_sas_metadata=dict(),
-                    common_ratio_to_sas_metadata=dict())
+        extra_attn_metadata_args = {}
+        if isinstance(attn_metadata_builder, AscendDSAMetadataBuilder):
+            extra_attn_metadata_args = dict(
+                        prefill_ratio_to_sas_metadata=dict(),
+                        decode_ratio_to_sas_metadata=dict(),
+                        common_ratio_to_sas_metadata=dict())
         attn_metadata = attn_metadata_builder.build(
             0,
             common_attn_metadata,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -49,7 +49,6 @@ from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
-from vllm.v1.attention.selector import get_attn_backend  # type: ignore
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.worker.utils import select_common_block_size
 from vllm.v1.kv_cache_interface import (
@@ -93,6 +92,7 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, using_paged_attention
+from vllm_ascend.patch.platform.patch_selector import get_attn_backend
 
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -2047,13 +2047,13 @@ class NPUModelRunner(GPUModelRunner):
             return {}, None
         num_tokens_padded = num_tokens_padded or num_tokens
         num_reqs_padded = num_reqs_padded or num_reqs
-        
+
         # check
         # attn_metadata: PerLayerAttnMetadata = {}
-        attn_metadata: dict[str, Any] = defaultdict(list)
-        
+        attn_metadata: dict[str, Any] = defaultdict(list) if self.use_compress else {}
+
         if ubatch_slices is not None:
-            attn_metadata = [dict() for _ in range(len(ubatch_slices))]
+            attn_metadata = [defaultdict(list) if self.use_compress else {} for _ in range(len(ubatch_slices))]
         if for_cudagraph_capture:
             # For some attention backends (e.g. FA) with sliding window models we need
             # to make sure the backend see a max_seq_len that is larger to the sliding
@@ -2244,7 +2244,10 @@ class NPUModelRunner(GPUModelRunner):
                 attn_metadata_dict = attn_metadata[ubid]
 
             for layer_name in attn_group.layer_names:
-                attn_metadata_dict[layer_name].append(attn_metadata_i)
+                if self.use_compress:
+                    attn_metadata_dict[layer_name].append(attn_metadata_i)
+                else:
+                    attn_metadata_dict[layer_name] = attn_metadata_i
 
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
@@ -2278,7 +2281,7 @@ class NPUModelRunner(GPUModelRunner):
                 cm.block_table_tensor, cm.slot_mapping = _get_block_table_and_slot_mapping(kv_cache_gid, total_num_scheduled_tokens_compressed_list)
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer):
-                    if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:
+                    if getattr(self.drafter, "kv_cache_gid", None) == kv_cache_gid:
                         spec_decode_common_attn_metadata = cm
                 else:
                     spec_decode_common_attn_metadata = cm
@@ -2300,10 +2303,18 @@ class NPUModelRunner(GPUModelRunner):
             if isinstance(attn_metadata, list):
                 for ub_metadata in attn_metadata:
                     for _metadata in ub_metadata.values():
-                        _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                        if self.use_compress:
+                            for metadata_i in _metadata:
+                                metadata_i.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                        else:
+                            _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
             else:
                 for _metadata in attn_metadata.values():
-                    _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                    if self.use_compress:
+                        for metadata_i in _metadata:
+                            metadata_i.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
+                    else:
+                        _metadata.mm_prefix_range = req_doc_ranges  # type: ignore[attr-defined]
 
         if spec_decode_common_attn_metadata is not None and (
             num_reqs != num_reqs_padded or num_tokens != num_tokens_padded
@@ -2960,7 +2971,7 @@ class NPUModelRunner(GPUModelRunner):
                     assert num_blocks == kv_cache_config.num_blocks, \
                         f"num_blocks: {num_blocks} should be equal to " \
                         f"kv_cache_config.num_blocks: {kv_cache_config.num_blocks}"
-                    kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+                    kv_cache_shape = attn_backend.get_kv_cache_shape(
                         num_blocks, current_kv_cache_spec.block_size,
                         current_kv_cache_spec.num_kv_heads,
                         current_kv_cache_spec.head_size)
@@ -2980,11 +2991,11 @@ class NPUModelRunner(GPUModelRunner):
                     assert num_blocks == kv_cache_config.num_blocks, \
                         f"num_blocks: {num_blocks} should be equal to " \
                         f"kv_cache_config.num_blocks: {kv_cache_config.num_blocks}"
-                    indexer_kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+                    indexer_kv_cache_shape = attn_backend.get_kv_cache_shape(
                         num_blocks, current_kv_cache_spec.block_size,
                         current_kv_cache_spec.num_kv_heads,
                         current_kv_cache_spec.head_size)
-                    indexer_scale_cache_shape = self.attn_backend.get_kv_cache_shape(
+                    indexer_scale_cache_shape = attn_backend.get_kv_cache_shape(
                         num_blocks, current_kv_cache_spec.block_size,
                         current_kv_cache_spec.num_kv_heads,
                         current_kv_cache_spec.indexer_scale_dim)
@@ -3039,8 +3050,14 @@ class NPUModelRunner(GPUModelRunner):
                     assert num_blocks >= kv_cache_config.num_blocks
 
                     if hasattr(attn_backend, "get_supported_kernel_block_sizes") and self.use_hybrid_blocks:
-                        block_size = attn_backend.get_supported_kernel_block_sizes()[0]
-
+                        if group.kv_cache_group_id >= len(self.kernel_block_sizes):
+                            block_size = attn_backend.get_supported_kernel_block_sizes()[0]
+                        else:
+                            kernel_block_size = self.kernel_block_sizes[group.kv_cache_group_id]
+                            if isinstance(kernel_block_size, list):
+                                block_size = int(kernel_block_size[0])
+                            else:
+                                block_size = int(kernel_block_size)
                         block_size_chunk = current_kv_cache_spec.block_size // block_size
                         kv_cache_shape = attn_backend.get_kv_cache_shape(
                             num_blocks * block_size_chunk,
@@ -3194,32 +3211,34 @@ class NPUModelRunner(GPUModelRunner):
                 # This is an attention backend that supports virtual
                 # block splitting. Get the supported block sizes from
                 # the backend.
-                
+
                 # This is an attention backend that supports virtual
                 # block splitting. Get the supported block sizes from
                 # all backends in the group.
-                attn_groups = self.attn_groups[kv_cache_group_id]
-                kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
-                selected_kernel_size = select_common_block_size(
-                    kv_manager_block_size, [attn_group.backend for attn_group in attn_groups]
-                )
-                self.kernel_block_sizes.append([selected_kernel_size])
-                
-                # try:
-                #     attn_groups = self.attn_groups[kv_cache_group_id]
-                # except IndexError:
-                #     attn_groups = None
-                # if attn_groups and self.use_hybrid_blocks:
-                #     # Use the backend's supported block size list
-                #     backend = attn_groups[0].backend
-                #     supported_sizes = backend.get_supported_kernel_block_sizes()
-                #     # If no specific sizes supported, use cache config
-                #     # block_size
-                #     kernel_block_size_list = supported_sizes if supported_sizes else [self.cache_config.block_size]
-                # else:
-                #     # Fallback to cache config block_size if no backend found
-                #     kernel_block_size_list = [self.cache_config.block_size]
-                # self.kernel_block_sizes.append(kernel_block_size_list)
+                if self.use_compress:
+                    attn_groups = self.attn_groups[kv_cache_group_id]
+                    kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
+                    selected_kernel_size = select_common_block_size(
+                        kv_manager_block_size,
+                        [attn_group.backend for attn_group in attn_groups],
+                    )
+                    self.kernel_block_sizes.append([selected_kernel_size])
+                else:
+                    try:
+                        attn_groups = self.attn_groups[kv_cache_group_id]
+                    except IndexError:
+                        attn_groups = None
+                    if attn_groups and self.use_hybrid_blocks:
+                        # Use the backend's supported block size list
+                        backend = attn_groups[0].backend
+                        supported_sizes = backend.get_supported_kernel_block_sizes()
+                        # If no specific sizes supported, use cache config
+                        # block_size
+                        kernel_block_size_list = supported_sizes if supported_sizes else [self.cache_config.block_size]
+                    else:
+                        # Fallback to cache config block_size if no backend found
+                        kernel_block_size_list = [self.cache_config.block_size]
+                    self.kernel_block_sizes.append(kernel_block_size_list)
             else:
                 # This is likely Mamba or other non-attention cache,
                 # no splitting.
@@ -3243,7 +3262,7 @@ class NPUModelRunner(GPUModelRunner):
             max_num_blocks.append(max_num_blocks_per_req)
 
         if block_sizes != [self.cache_config.block_size] or self.kernel_block_sizes != [[self.cache_config.block_size]] \
-            or len(kv_cache_config.kv_cache_groups) > 1:
+            or (self.use_compress and len(kv_cache_config.kv_cache_groups) > 1):
             assert self.offload_config.uva.cpu_offload_gb == 0, (
                 "Cannot re-initialize the input batch when CPU weight "
                 "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501


### PR DESCRIPTION
## What this PR does / why we need it?

- restore selector compatibility across the legacy and current upstream `get_attn_backend` signatures used in this branch
- keep compressed C4/indexer KV cache reshapes on their physical block size while using the selected hybrid kernel size only where draft slot mapping depends on it
- preserve the non-compress attention metadata path and keep DeepSeek V4 MTP layers on the uncompressed SWA cache spec
- add regression coverage for the selector patch, hybrid KV cache handling, and speculative drafting block-size selection

## Does this PR introduce _any_ user-facing change?

Yes. It fixes DeepSeek V4 serving stability and preserves the existing non-DeepSeek runtime path in this branch, without adding a new public API.

## How was this patch tested?

- `pytest -sv tests/ut/spec_decode/test_eagle_proposer.py`
- `pytest -sv tests/ut/worker/test_model_runner_v1.py`
- `pytest -sv tests/ut/patch/platform/test_patch_selector.py`
- `bash /tmp/bench all`
- `~/../src/v4/0.18.0-ds/tools/smoke_model_matrix.py --suite all`
