### PR TITLE
[Bugfix][DSA] Pass seqUsed to compressor

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -46,6 +46,10 @@ BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
 
 
+def _seq_lens_from_cu_seqlens(cu_seqlens: torch.Tensor) -> torch.Tensor:
+    return (cu_seqlens[1:] - cu_seqlens[:-1]).contiguous()
+
+
 def hadamard_transform_ref(x: torch.Tensor, hadamard: torch.Tensor, scale:int =1.0,):
     x_shape = x.shape
     dim = x.shape[-1]
@@ -1348,7 +1352,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 kv_block_table=compressor_kv_state_metadata.prefill.block_table,
                 score_block_table=compressor_score_state_metadata.prefill.block_table,
                 cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
+                seqused=_seq_lens_from_cu_seqlens(actual_seq_lengths_query),
                 start_pos=compress_common_attn_metadata.prefill.start_pos,
                 rope_head_dim=self.rope_head_dim,
                 cmp_ratio=self.compress_ratio,
@@ -1557,7 +1561,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 kv_block_table=compressor_kv_state_metadata.decode.block_table,
                 score_block_table=compressor_score_state_metadata.decode.block_table,
                 cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
+                seqused=_seq_lens_from_cu_seqlens(actual_seq_lengths_query),
                 start_pos=compress_common_attn_metadata.decode.start_pos,
                 rope_head_dim=self.rope_head_dim,
                 cmp_ratio=self.compress_ratio,
@@ -1698,7 +1702,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv_block_table=kv_block_table,
             score_block_table=score_block_table,
             cu_seqlens=actual_seq_lengths_query,
-            seqused=None,
+            seqused=_seq_lens_from_cu_seqlens(actual_seq_lengths_query),
             start_pos=start_pos,
             rope_head_dim=self.rope_head_dim,
             cmp_ratio=self.compress_ratio,


### PR DESCRIPTION
## What this PR does / why we need it?

This PR fixes the DeepSeek-V4-Pro DSA C4 accuracy collapse by passing explicit sequence lengths to the compressor operator.

Previously, DSA called `torch.ops._C_ascend.compressor` with `seqused=None`. Standalone compressor probes showed that the TH-layout optional-null `seqUsed` path can produce invalid compressed KV values, including NaNs or zero-like rows. Once the prompt reaches the C4 boundary, these bad compressed KV values are consumed by attention and the model can emit BOS or garbage output.

The fix is intentionally minimal: derive `seqused` from `cu_seqlens` at the call site and pass it to the three compressor invocations in `dsa_v1.py`:

```python
seqused = cu_seqlens[1:] - cu_seqlens[:-1]
```

Related issue: #76

## Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-V4-Pro completions should no longer collapse at the C4 compression boundary when using the DSA path.

## How was this patch tested?

- `python -m py_compile vllm_ascend/attention/dsa_v1.py`
- Manual DeepSeek-V4-Pro serving with `../v2.sh --enforce-eager`
- `/v1/completions` deterministic probes:
  - `"a b c" -> " d"`
  - `"a b c d" -> " e"`
  - `"one two three four" -> " five"`
  - `"a b c d"`, `max_tokens=5` -> `" e f g h i"`

## Notes

This PR is a call-site fix to avoid the known-bad compressor optional-null path. The compressor operator should still be fixed separately so that TH layout with `seqUsed == nullptr` is either handled correctly or rejected/redirected to a safe path.

- vLLM version:
- vLLM main: