### PR TITLE
[Bugfix][Scheduler] 支持 async response_format 调度标记

### DIFF
--- a/tests/ut/core/test_kv_state_scheduler.py
+++ b/tests/ut/core/test_kv_state_scheduler.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from vllm.v1.core.sched.output import SchedulerOutput
+
+from vllm_ascend.core.kv_state_scheduler import AsyncKVStateScheduler
+
+
+def test_async_kv_state_scheduler_marks_structured_decode_request():
+    scheduler = object.__new__(AsyncKVStateScheduler)
+    scheduler.num_spec_tokens = 2
+    scheduler._spec_token_placeholders = [-1, -1]
+    scheduler.finished_req_ids = {"finished"}
+    scheduler._free_encoder_inputs = MagicMock()
+
+    prefill_req = SimpleNamespace(
+        num_computed_tokens=0,
+        num_tokens=5,
+        num_output_placeholders=0,
+        use_structured_output=True,
+        has_encoder_inputs=False,
+        spec_token_ids=[],
+        is_prefill_chunk=False,
+    )
+    decode_req = SimpleNamespace(
+        num_computed_tokens=5,
+        num_tokens=5,
+        num_output_placeholders=0,
+        use_structured_output=True,
+        has_encoder_inputs=False,
+        spec_token_ids=[],
+        is_prefill_chunk=False,
+    )
+    scheduler.requests = {
+        "prefill": prefill_req,
+        "decode": decode_req,
+    }
+
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {
+        "prefill": 3,
+        "decode": 1,
+    }
+    scheduler_output.total_num_scheduled_tokens = 4
+
+    scheduler._update_after_schedule(scheduler_output)
+
+    assert scheduler_output.has_structured_output_requests
+    assert not scheduler_output.pending_structured_output_tokens
+    assert prefill_req.is_prefill_chunk
+    assert prefill_req.num_output_placeholders == 0
+    assert not decode_req.is_prefill_chunk
+    assert decode_req.num_output_placeholders == 1
+    assert decode_req.spec_token_ids is scheduler._spec_token_placeholders
+    assert scheduler.finished_req_ids == set()

--- a/vllm_ascend/core/kv_state_scheduler.py
+++ b/vllm_ascend/core/kv_state_scheduler.py
@@ -720,48 +720,6 @@ class KVStateScheduler(Scheduler):
 
 
 class AsyncKVStateScheduler(AsyncScheduler, KVStateScheduler):
+    """Use upstream async updates while retaining KV-state scheduling."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def _update_after_schedule(
-        self,
-        scheduler_output: SchedulerOutput,
-    ) -> None:
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
-        for req_id, num_scheduled_token in num_scheduled_tokens.items():
-            request = self.requests[req_id]
-            request.num_computed_tokens += num_scheduled_token
-
-            # NOTE: _free_encoder_inputs relies on num_computed_tokens, which
-            # may be updated again in _update_from_output for speculative
-            # decoding. However, it is safe to call the method here because
-            # encoder inputs are always part of the prompt, not the output,
-            # and thus are unaffected by speculative decoding.
-            if request.has_encoder_inputs:
-                self._free_encoder_inputs(request)
-
-        # Clear the finished request IDs.
-        # NOTE: We shouldn't do self.finished_req_ids.clear() here because
-        # it will also affect the scheduler output.
-        self.finished_req_ids: set[str] = set()
-
-        pending_structured_output_tokens = False
-        spec_decode_tokens = scheduler_output.scheduled_spec_decode_tokens
-        for req_id in scheduler_output.num_scheduled_tokens:
-            request = self.requests[req_id]
-            pending_structured_output_tokens |= (
-                request.use_structured_output
-                and request.num_output_placeholders > 0)
-            cur_num_spec_tokens = len(spec_decode_tokens.get(req_id, ()))
-            if (request.num_computed_tokens == request.num_tokens +
-                    request.num_output_placeholders + cur_num_spec_tokens):
-                # The request will generate a new token plus num_spec_tokens
-                # in this scheduling step.
-                request.num_output_placeholders += 1 + cur_num_spec_tokens
-                # Add placeholders for the new tokens in spec_token_ids.
-                # We will update the actual spec token ids in the worker process.
-                request.spec_token_ids = [0] * self.num_spec_tokens
-
-        scheduler_output.pending_structured_output_tokens = (
-            pending_structured_output_tokens)
+    pass


### PR DESCRIPTION
### What this PR does / why we need it?

修复 DeepSeek V4 Flash 在 `--async-scheduling` 下使用 OpenAI `response_format` 时 structured output 调度标记没有正确设置的问题。

当前 `AsyncKVStateScheduler` 保留了一份旧版 `_update_after_schedule()` 覆盖实现，遮蔽了 vLLM 0.18 中 `AsyncScheduler` / `Scheduler` 对 structured output 的新逻辑，导致 `scheduler_output.has_structured_output_requests` 可能不会被设置，从而 `get_grammar_bitmask()` 返回 `None`，response format grammar mask 无法生效。

本 PR：

- 保留 `AsyncKVStateScheduler` 类和 Ascend KV-state scheduling 能力。
- 移除过期的本地 `_update_after_schedule()` 覆盖，让其继承 vLLM 0.18 上游 async scheduler 更新逻辑。
- 新增单测覆盖 structured decode request 设置 `has_structured_output_requests`、prefill/decode 标记以及 async placeholder 行为。

关联 issue: #78

### Does this PR introduce _any_ user-facing change?

是。对于 `--async-scheduling` 下的 OpenAI structured output 请求，`response_format` 能正确触发 grammar bitmask 生成并约束输出。

已验证的请求类型：

- `response_format.type=json_schema`
- `response_format.type=json_object`

`structural_tag` 理论上走同一 structured output 路径，但本 PR 未做 real-weight 请求验证，已在 #78 中记录为后续项。

### How was this patch tested?

本地单测：

```bash
pytest -q tests/ut/core/test_kv_state_scheduler.py
pytest -q tests/ut/patch/platform/test_patch_deepseek_v4_agentic.py
ruff check tests/ut/core/test_kv_state_scheduler.py
ruff format --check tests/ut/core/test_kv_state_scheduler.py
git diff --check
```

Real-weight DeepSeek V4 Flash 服务验证，使用 `../v2-flash.sh`，不启用 MTP：

- `GET /v1/models`: HTTP 200，模型名 `dsv4`
- 普通 `/v1/chat/completions`: HTTP 200，非空输出
- `response_format.type=json_schema`: HTTP 200，输出可解析为 JSON，符合 schema
- `response_format.type=json_object`: HTTP 200，输出可解析为 JSON object
- 日志显示 ACL Graph replay，无 structured-output / grammar / scheduler 错误

补充说明：重新打开 MTP 后，服务在 engine 初始化阶段失败，未到达 `/v1/models`。失败点为 `vllm_ascend/worker/model_runner_v1.py` 的 KV cache tensor layer-name 校验：

```text
assert layer_names == set(kv_cache_raw_tensors.keys()), "Some layers are not correctly initialized"
```

该失败发生在 scheduler 构造之前，不是本 PR 中 `AsyncKVStateScheduler` post-schedule 修复引起；后续跟进项记录在 #78。
