### PR TITLE
[Bugfix] Align compressor PERF hidden-axis start

### DIFF
--- a/csrc/attention/compressor/op_kernel/arch32/compressor_block_cube_perf.h
+++ b/csrc/attention/compressor/op_kernel/arch32/compressor_block_cube_perf.h
@@ -405,7 +405,7 @@ __aicore__ inline void CompressorBlockCubePerf<COMP>::ComputeMm1(const RunInfo &
 
     // hSize为K_SIZE=512的倍数
     uint32_t hSize = constInfo_.hSize;
-    uint32_t hIdxStart = (constInfo_.aiCoreIdx % constInfo_.dBasicBlockNum) * (hSize / constInfo_.dBasicBlockNum);  // 每组核内的h循环起始不同
+    uint32_t hIdxStart = (constInfo_.aiCoreIdx % constInfo_.dBasicBlockNum) * K_L1_BASE;  // 每组核内的h循环起始不同
     for (uint32_t h = 0; h < hSize; h += K_SIZE) {
         for (uint32_t k = 0; k < K_SIZE; k += K_L1_BASE) {
             bool isFirst = (h == 0 && k == 0);


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the DeepSeek-V4 Pro compressor PERF path by aligning the per-core hidden-axis start with the kernel copy block size:

```cpp
uint32_t hIdxStart = (constInfo_.aiCoreIdx % constInfo_.dBasicBlockNum) * K_L1_BASE;
```

The previous stride used `hSize / constInfo_.dBasicBlockNum`. For DeepSeek-V4 Pro with `hidden_size=7168`, that stride does not keep the PERF copy window aligned to the `K_L1_BASE` hidden block layout. Near the final hidden block, the computed start can cross the hidden-row boundary and corrupt the last element written into KV state / score state for each token.

This is the operator-side fix for the issue previously worked around by passing `seqUsed`, which forced the compressor into the NORMAL template. With this change, Pro can keep the PERF path while preserving correctness.

Related to #76.

### Does this PR introduce _any_ user-facing change?

No public API or configuration change. The change is limited to the compressor custom operator implementation.

### How was this patch tested?

- Rebuilt and installed the compressor custom operator.
- Launched DeepSeek-V4 Pro with `../v2.sh --port 8900 --enforce-eager` after sourcing the custom op environment.
- Confirmed `GET /v1/models` returns successfully.
- Ran a standalone compressor probe for `hidden_size=7168`, `seqUsed=nullptr`; after the fix, row cosine against reference was about `0.9999988` and no KV / score NaNs were observed.
- Started the real DeepSeek-V4 Pro accuracy repeat test in background using the prompt from `../curl.py`, `temperature=0`, `enable_thinking=True`, `max_tokens=3800` under `max_model_len=4096`. Current status at PR creation: 9 / 20 runs passed, all returned `Answer: B`, `finish_reason=stop`, and no 8-gram / 16-gram repetition was observed. Full background output: `artifacts/dsv4_pro_v2sh_tp8dp2_eager_customop_20x/repeat_curlpy_20x_maxtok3800.jsonl`.
