### PR TITLE
[Bugfix] Re-enable compressor PERF path

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -46,10 +46,6 @@ BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
 
 
-def _seq_lens_from_cu_seqlens(cu_seqlens: torch.Tensor) -> torch.Tensor:
-    return (cu_seqlens[1:] - cu_seqlens[:-1]).contiguous()
-
-
 def hadamard_transform_ref(x: torch.Tensor, hadamard: torch.Tensor, scale:int =1.0,):
     x_shape = x.shape
     dim = x.shape[-1]
@@ -1352,7 +1348,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 kv_block_table=compressor_kv_state_metadata.prefill.block_table,
                 score_block_table=compressor_score_state_metadata.prefill.block_table,
                 cu_seqlens=actual_seq_lengths_query,
-                seqused=_seq_lens_from_cu_seqlens(actual_seq_lengths_query),
+                seqused=None,
                 start_pos=compress_common_attn_metadata.prefill.start_pos,
                 rope_head_dim=self.rope_head_dim,
                 cmp_ratio=self.compress_ratio,
@@ -1561,7 +1557,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 kv_block_table=compressor_kv_state_metadata.decode.block_table,
                 score_block_table=compressor_score_state_metadata.decode.block_table,
                 cu_seqlens=actual_seq_lengths_query,
-                seqused=_seq_lens_from_cu_seqlens(actual_seq_lengths_query),
+                seqused=None,
                 start_pos=compress_common_attn_metadata.decode.start_pos,
                 rope_head_dim=self.rope_head_dim,
                 cmp_ratio=self.compress_ratio,
@@ -1702,7 +1698,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv_block_table=kv_block_table,
             score_block_table=score_block_table,
             cu_seqlens=actual_seq_lengths_query,
-            seqused=_seq_lens_from_cu_seqlens(actual_seq_lengths_query),
+            seqused=None,
             start_pos=start_pos,
             rope_head_dim=self.rope_head_dim,
             cmp_ratio=self.compress_ratio,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR reverts commit `669833a74c7eb9e89a741901f8cfb236a6ef4795` from PR #77.

PR #77 was a temporary call-site workaround for the DeepSeek-V4 Pro compressor accuracy issue. It passed `seqUsed` derived from `cu_seqlens` so the compressor operator avoided the optional-null path and selected the NORMAL template instead of the PERF template.

Now that PR #83 has fixed the compressor PERF kernel by aligning `hIdxStart` with `K_L1_BASE`, keeping PR #77 would continue to bypass the fixed PERF path. Reverting it restores `seqused=None` at the DSA compressor call sites so DeepSeek-V4 can exercise the PERF path again.

### Does this PR introduce _any_ user-facing change?

No public API or configuration change. Internally, DSA compressor calls return to the PERF operator path when `seqUsed` is omitted.

### How was this patch tested?

- Verified the revert only removes the temporary `_seq_lens_from_cu_seqlens` helper and restores three compressor call sites to `seqused=None`.
- Ran `python -m py_compile vllm_ascend/attention/dsa_v1.py`.

Runtime accuracy/performance validation should be run with the merged PR #83 custom operator so this PR actually exercises the fixed PERF path.
