### PR TITLE
[Bugfix][Kernel] Guard ScatterNdUpdateV2 sort by physical range

### DIFF
--- a/csrc/moe/scatter_nd_update_v2/op_host/scatter_nd_update_v2_tiling.cpp
+++ b/csrc/moe/scatter_nd_update_v2/op_host/scatter_nd_update_v2_tiling.cpp
@@ -336,7 +336,7 @@ ge::graphStatus ScatterNdUpdateV2Tiling::Init()
         isSort_ = false;
         isLinearIndex_ = false;
     } else {
-        isSort_ = IsSort(totalLength, indexRow);
+        isSort_ = false;
         isLinearIndex_ = IsLinearIndex(totalLength);
     }
     coreNum_ = std::min(compileInfo->totalCoreNum,
@@ -345,13 +345,16 @@ ge::graphStatus ScatterNdUpdateV2Tiling::Init()
     ubSize_ = compileInfo->ubSizePlatForm;
     GetDtypeSize();
     Tiling4LinearIndex(indexRow, indexDim_);
-    SetTilingKeyMode();
-    tilingContext_->SetScheduleMode(1);
     uint64_t maxPhysicalOffset = 0;
     for (uint64_t i = 0; i < indexDim_; ++i) {
         maxPhysicalOffset += (varRefShape.GetDim(i) - 1) * indicesMask_[i];
     }
     uint64_t totalPhysicalRange = maxPhysicalOffset + scatterLength_;
+    if (!needLargeIndexKernel_) {
+        isSort_ = IsSort(totalPhysicalRange, indexRow);
+    }
+    SetTilingKeyMode();
+    tilingContext_->SetScheduleMode(1);
     Tiling4Scatter(totalPhysicalRange, indexRow);
     size_t* currentWorkSpace = tilingContext_->GetWorkspaceSizes(1);
     currentWorkSpace[0] = CalcWorkSpaceSize(indexRow);


### PR DESCRIPTION
## What this PR does / why we need it?

Fixes GDzhu01/vllm-ascend-deepseekv4#90.

DeepSeek-V4-Flash-w8a8-mtp can drift on long repeated outputs on the Ascend eager + EP + shared hybrid KV path. Short outputs are normal, but long decode may start correctly and later repeat `(-1,0)/(0,-1)` text or lose the final `Answer: ...` template.

This PR is intentionally minimal. It keeps vLLM hybrid KV `shared_by` sharing enabled, keeps prefix/KV cache reuse, does not use a no-share workaround, and does not change block reuse order.

## Root cause

The allocator high physical block id was the trigger, not the bug.

The operator-level root cause is in `npu_scatter_nd_update_v2`:

- The binding passes `var.strides()` into `aclnnScatterNdUpdateV2`.
- The kernel computes a strided physical linear index: `sum(index[i] * stride[i])`.
- Host tiling previously decided whether to use the sort path from the logical indexed shape product, for example `num_blocks * block_size`.
- The sort path casts the int32 linear index to fp32 for `Sort<float, true>`, then casts it back to int32.
- fp32 cannot exactly represent every integer above `2^24`.
- For the DSA scale cache view, `stride0 = 8320`, so physical block ids around `ceil(2^24 / 8320) = 2017` can produce rounded linear addresses.
- In the reproduced bad case, block id `2086` and offset `127` produce linear offset `17,355,647`, which rounds to `17,355,648` in the fp32 sort path. The write lands at the adjacent element, and long decode later forgets earlier context/template.

So high physical ids fail because they push the strided physical address beyond the fp32 exact-integer range used by the sort path. Physical blocks do not need to be compact, and KV sharing is not the underlying problem.

## Fix

- Run `Tiling4LinearIndex()` before deciding sort eligibility so tiling has the stride-derived `indicesMask_`.
- Compute the real strided physical address range from `var.shape`, `var.strides()`, and `scatterLength_`.
- Decide the fp32 sort path using that physical range instead of the logical indexed shape product.
- Fall back to the no-sort int32 path when the physical range exceeds the fp32 exact-integer limit.

## Does this PR introduce _any_ user-facing change?

No. This only changes custom operator tiling selection. It does not change public APIs, environment variables, prefix cache behavior, `shared_by`, or KV cache ownership semantics.

## How was this patch tested?

Operator-level microbenchmark:

```text
fp32_exact_int_limit=16777215, threshold_block=ceil(2^24/8320)=2017
low_control: block_id=1000, offset=127, linear=8320127, target=[3.0], relative_nonzero=[0]
high_regression: block_id=2086, offset=127, linear=17355647, target=[7.0], relative_nonzero=[0]
```

Before the tiling fix, the high case wrote at relative `+1` and left the target as `0.0`. After the fix, the target is written correctly.

Real-weight operator-only serving validation:

- Model: `/models/DeepSeek-V4-Flash-w8a8-mtp`
- Startup: copied script `../v4_shared_kv.sh`, not `../v4.sh`
- Flags include `--max-model-len 8192`, `--enforce-eager`, EP enabled, MTP disabled
- Request: same repro prompt via `../curl_debug.py --max-tokens 4096`
- Branch: `exp/dsv4-operator-only`
- Diff: only `csrc/moe/scatter_nd_update_v2/op_host/scatter_nd_update_v2_tiling.cpp`
- Artifact: `logs/code/operator_only_requests_20260503_224903_mt4096/summary.tsv`

Result:

```text
runs: 30
non_answer_b: 0
old_bad_hash_nonzero: 0
repeat_markers_dist: {'4': 1, '5': 29}
```

All 30 requests ran in the same vLLM server process without restart. Prefix cache hit rate increased to about `51.9%`, so this covers the shared prefix/KV reuse path as well as the original run 4/run 6 failure window.

The PR diff is intentionally limited to one source file:

```text
csrc/moe/scatter_nd_update_v2/op_host/scatter_nd_update_v2_tiling.cpp | 9 ++++++---
```
