### PR TITLE
[Bugfix][MC2] Fix Pro W4A8 fused MC2 UB overflow

### DIFF
--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8.h
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8.h
@@ -229,7 +229,9 @@ __aicore__ inline void DispatchFFNCombineW4A8<TemplateMMA2ACFunc>::Process()
     using TileCopyMmad =
         Gemm::Tile::QuantTileCopy<ArchTag, AType, BType, CType, void, ScaleGranularity::PER_CHANNEL>;
     using BlockMmad = Gemm::Block::BlockMmad<DispatchPolicy, L1TileShape, L0TileShape, AType, BType, CType, void, TileCopyMmad>;
-    constexpr uint32_t ubStages = 2;
+    // W4A8 SwiGLU needs extra UB buffers for int4 packing. A double-buffered
+    // epilogue overflows UB for 6144-wide gate/up projections.
+    constexpr uint32_t ubStages = 1;
 
     using EpilogueDispatchPolicy1 = Epilogue::EpilogueAtlasA2W4A8PostPerTokenDequantSwigluQuant<ubStages>;
 

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py
@@ -111,19 +111,25 @@ class TestDispatchFFNCombine:
                                    dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
+        bias1 = torch.zeros((e, n), dtype=torch.float32).npu()
+        bias2 = torch.zeros((e, n2), dtype=torch.float32).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()
 
         weight1_nz_npu = []
         weight2_nz_npu = []
         scale1_npu = []
         scale2_npu = []
+        bias1_npu = []
+        bias2_npu = []
         for i in range(e):
             weight1_nz_npu.append(
-                torch_npu.npu_format_cast(weight1[i].npu(), 29))
+                torch_npu.npu_format_cast(weight1[i].npu(), 29).view(torch.int32))
             scale1_npu.append(scale1[i].npu())
+            bias1_npu.append(bias1[i].npu())
             weight2_nz_npu.append(
-                torch_npu.npu_format_cast(weight2[i].npu(), 29))
+                torch_npu.npu_format_cast(weight2[i].npu(), 29).view(torch.int32))
             scale2_npu.append(scale2[i].npu())
+            bias2_npu.append(bias2[i].npu())
 
         out = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
         expert_token_nums = self.generate_random_tensor((1, e), dtype=torch.int32).npu()
@@ -135,9 +141,12 @@ class TestDispatchFFNCombine:
             expert_idx=expert_idx,
             scale1=scale1_npu,
             scale2=scale2_npu,
+            bias1=bias1_npu,
+            bias2=bias2_npu,
             probs=probs,
             group=self.hcomm_info,
             max_output_size=512,
+            swiglu_limit=0.0,
             out=out,
             expert_token_nums=expert_token_nums,
         )
@@ -167,16 +176,22 @@ class TestDispatchFFNCombine:
                                    dtype=torch.int32).npu()
         scale1 = torch.randint(0, 1, (e, n), dtype=torch.int64).npu()
         scale2 = torch.randint(0, 1, (e, n2), dtype=torch.int64).npu()
+        bias1 = torch.zeros((e, n), dtype=torch.float32).npu()
+        bias2 = torch.zeros((e, n2), dtype=torch.float32).npu()
         probs = torch.randn(size=(m, topk), dtype=torch.float32).npu()
 
         weight1_nz_npu = []
         weight2_nz_npu = []
         scale1_npu = []
         scale2_npu = []
-        weight1_nz_npu.append(torch_npu.npu_format_cast(weight1.npu(), 29))
+        bias1_npu = []
+        bias2_npu = []
+        weight1_nz_npu.append(torch_npu.npu_format_cast(weight1.npu(), 29).view(torch.int32))
         scale1_npu.append(scale1.npu())
-        weight2_nz_npu.append(torch_npu.npu_format_cast(weight2.npu(), 29))
+        bias1_npu.append(bias1.npu())
+        weight2_nz_npu.append(torch_npu.npu_format_cast(weight2.npu(), 29).view(torch.int32))
         scale2_npu.append(scale2.npu())
+        bias2_npu.append(bias2.npu())
 
         out = self.generate_random_tensor((m, k), dtype=torch.bfloat16).npu()
         expert_token_nums = self.generate_random_tensor((1, e), dtype=torch.int32).npu()
@@ -188,9 +203,12 @@ class TestDispatchFFNCombine:
             expert_idx=expert_idx,
             scale1=scale1_npu,
             scale2=scale2_npu,
+            bias1=bias1_npu,
+            bias2=bias2_npu,
             probs=probs,
             group=self.hcomm_info,
             max_output_size=512,
+            swiglu_limit=0.0,
             out=out,
             expert_token_nums=expert_token_nums,
         )

--- a/tests/ut/ops/test_dispatch_ffn_combine_w4a8.py
+++ b/tests/ut/ops/test_dispatch_ffn_combine_w4a8.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_w4a8_fused_epilogue_uses_single_ub_stage():
+    repo_root = Path(__file__).parents[3]
+    header = repo_root / "csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/dispatch_ffn_combine_w4_a8.h"
+
+    assert "constexpr uint32_t ubStages = 1;" in header.read_text()


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #92

本 PR 修复 DeepSeek-V4-Pro W4A8 在 fused MC2 dispatch FFN combine 的 SwiGLU 路径上可能触发 UB 溢出的问题。

根因是 W4A8 SwiGLU epilogue 需要额外 UB buffer 做 int4 packing，而当前 W4A8 fused MC2 epilogue 使用双 UB stage。Pro 的 intermediate size 为 3072，fused gate/up 宽度为 6144，在该形状下双 stage 会超过 UB 容量。Flash 的 intermediate size 为 2048，fused gate/up 宽度为 4096，因此不会触发同样问题。

改动范围：

- 仅将 W4A8 fused MC2 epilogue 的 `ubStages` 从 2 改为 1。
- W8A8/BF16 fused MC2 仍保持 `ubStages = 2`，不改变其行为。
- 更新 A3 dispatch FFN combine e2e 用例，使 W4A8 binding 按当前接口传入 `bias1`、`bias2` 和 `swiglu_limit`，并通过 `.view(torch.int32)` 选择 W4A8 op。
- 新增一个轻量 UT，防止 W4A8 UB stage 回退成 2。

### Does this PR introduce _any_ user-facing change?

No. 这是 W4A8 fused MC2 自定义算子内部 UB staging 修复，不改变用户侧 API、启动参数或模型行为。

### How was this patch tested?

本地静态和单测：

- `pytest -q tests/ut/ops/test_dispatch_ffn_combine_w4a8.py`
- `ruff check tests/ut/ops/test_dispatch_ffn_combine_w4a8.py tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py`

A3 op 测试：

- `pytest -sv tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py`
- 结果：`1 passed`

双机 A3 Pro W4A8 真实权重验证：

- 模型：`/models/DeepSeek-V4-Pro-w4a8-fixmtp`
- 并行：TP16 / DP2 / EP
- `VLLM_ASCEND_ENABLE_FUSED_MC2=1`
- `--quantization ascend`
- MTP speculative decoding 开启
- eager mode

验证结果：

- `/health` 返回 200。
- 真实 chat 请求返回 200，确定性结果为 `42,72`。
- 并发两条短请求返回 200，结果分别为 `12` 和 `90`。
- node0 日志出现 `SpecDecoding metrics`，确认 MTP 路径实际运行。
- node0/node1 近期日志未发现自定义算子缺失、UB、`RuntimeError`、`Traceback`、HCCL/Gloo fatal/error 等异常模式。