### PR TITLE
[Bugfix][KV] Stabilize DeepSeek-V4 shared hybrid KV cache

### DIFF
--- a/tests/ut/patch/platform/test_patch_kv_cache_interface.py
+++ b/tests/ut/patch/platform/test_patch_kv_cache_interface.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.v1.core.block_pool import BlockPool
+
+import vllm_ascend.patch.platform.patch_kv_cache_interface  # noqa: F401
+
+
+def test_block_pool_reuses_freed_blocks_first_when_enabled():
+    block_pool = BlockPool(num_gpu_blocks=10,
+                           enable_caching=True,
+                           hash_block_size=128)
+    block_pool._ascend_reuse_freed_blocks_first = True
+
+    first_blocks = block_pool.get_new_blocks(3)
+    second_blocks = block_pool.get_new_blocks(2)
+    assert [block.block_id for block in first_blocks] == [1, 2, 3]
+    assert [block.block_id for block in second_blocks] == [4, 5]
+
+    block_pool.free_blocks(reversed(first_blocks))
+
+    reused_blocks = block_pool.get_new_blocks(3)
+    assert [block.block_id for block in reused_blocks] == [1, 2, 3]

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -15,13 +15,16 @@
 
 import math
 import os
+from types import SimpleNamespace
 from threading import Lock
 from unittest import mock
 
+import numpy as np
 import pytest
 import torch
 from vllm.config import (CompilationConfig, ModelConfig, ParallelConfig,
                          VllmConfig)
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
@@ -155,6 +158,36 @@ class TestUtils(TestBase):
         utils.vllm_version_is("1.0.0")
         hits = utils.vllm_version_is.cache_info().hits
         self.assertEqual(hits, 1)
+
+    def test_get_compressed_pos_counts_complete_windows_only(self):
+        kv_cache_spec = MLAAttentionSpec(block_size=128,
+                                         num_kv_heads=1,
+                                         head_size=8,
+                                         dtype=torch.float32,
+                                         compress_ratio=4,
+                                         model_version="svf")
+        kv_cache_groups = [SimpleNamespace(kv_cache_spec=kv_cache_spec)]
+        num_computed_tokens = np.array([0, 3, 4, 7, 240], dtype=np.int32)
+        num_scheduled_tokens = np.array([3, 1, 1, 5, 40], dtype=np.int32)
+        arrange_np = np.arange(num_computed_tokens.shape[0], dtype=np.int32)
+
+        positions, req_indices, counts = utils.get_compressed_pos_and_indices(
+            num_computed_tokens,
+            num_scheduled_tokens,
+            arrange_np,
+            True,
+            kv_cache_groups,
+        )
+
+        np.testing.assert_array_equal(counts[0],
+                                      np.array([0, 1, 0, 2, 10],
+                                               dtype=np.int32))
+        np.testing.assert_array_equal(
+            positions[0],
+            np.array([0, 1, 2, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]))
+        np.testing.assert_array_equal(
+            req_indices[0],
+            np.array([1, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]))
 
     def test_get_max_hidden_layers(self):
         from transformers import PretrainedConfig

--- a/tests/ut/worker/test_block_table.py
+++ b/tests/ut/worker/test_block_table.py
@@ -14,11 +14,13 @@
 #
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import torch
 from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.v1.kv_cache_interface import MLAAttentionSpec, UniformTypeKVCacheSpecs
 
 from tests.ut.base import TestBase
 
@@ -252,6 +254,54 @@ class TestBlockTableComputeSlotMapping(TestBase):
                                           pcp_world_size=2,
                                           cp_kv_cache_interleave_size=128,
                                           test_configs=test_configs)
+
+    def test_uniform_type_compress_ratio_resizes_block_table(self):
+        from vllm_ascend.worker.block_table import BlockTable
+
+        spec = UniformTypeKVCacheSpecs.from_specs({
+            "layer.0":
+            MLAAttentionSpec(block_size=128,
+                             num_kv_heads=1,
+                             head_size=8,
+                             dtype=torch.float32,
+                             compress_ratio=4,
+                             model_version="svf"),
+            "layer.1":
+            MLAAttentionSpec(block_size=128,
+                             num_kv_heads=1,
+                             head_size=16,
+                             dtype=torch.float32,
+                             compress_ratio=4,
+                             model_version="svf"),
+        })
+        assert spec is not None
+        block_table = BlockTable(
+            block_size=128,
+            max_num_reqs=2,
+            max_num_blocks_per_req=64,
+            max_num_batched_tokens=16,
+            pin_memory=False,
+            device=torch.device("cpu"),
+            kernel_sizes=[128],
+            kv_cache_group=SimpleNamespace(kv_cache_spec=spec),
+        )
+
+        self.assertEqual(block_table.max_num_blocks_per_req, 16)
+        self.assertEqual(block_table.block_table.np.shape, (2, 16))
+
+    def test_add_row_clears_stale_block_ids(self):
+        block_table = self.create_block_table(dcp_world_size=1,
+                                              dcp_rank=0,
+                                              pcp_world_size=1,
+                                              pcp_rank=0,
+                                              cp_kv_cache_interleave_size=1)
+        block_table.add_row([11, 12, 13, 14], 0)
+        block_table.add_row([21], 0)
+
+        np.testing.assert_array_equal(block_table.block_table.np[0, :4],
+                                      np.array([21, 0, 0, 0],
+                                               dtype=np.int32))
+        self.assertEqual(block_table.num_blocks_per_row[0], 1)
 
 
 if __name__ == '__main__':

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -591,14 +591,16 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             pad_positions = F.pad(input_positions, (0, pad_right), value=0.0)
             return pad_positions
 
-        def _get_cmp_seq_lens(prefill_seq_lens, compress_ratio):
+        def _get_cmp_seq_lens(seq_lens, compress_ratio):
             # Note(qcs): some models use compress_ratio=0 as non-compression tag.
             _cmp_seq_lens = (
-                prefill_seq_lens // compress_ratio if compress_ratio >= 1 
-                else prefill_seq_lens
+                seq_lens // compress_ratio if compress_ratio >= 1
+                else seq_lens
             )
             return torch.concat(
-                (torch.tensor([0], device=_cmp_seq_lens.device),
+                (torch.zeros(1,
+                             dtype=_cmp_seq_lens.dtype,
+                             device=_cmp_seq_lens.device),
                  torch.cumsum(_cmp_seq_lens, -1)),
                 dim=-1)
 
@@ -612,10 +614,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             mask = ((decode_input_positions + 1) % compress_ratio) == 0
             compressed_decode_num = mask.sum()
 
-            end = min(
-                self.num_prefill_tokens,
-                self.num_prefill_tokens // compress_ratio + self.num_prefills)
-            return compressed_decode_num, end
+            prefill_mask = ((prefill_input_positions + 1) %
+                            compress_ratio) == 0
+            prefill_compressed_num = prefill_mask.sum()
+            return compressed_decode_num, prefill_compressed_num
 
         if self.prefill_ratio_to_sas_metadata.get(f"c{self.compressor_ratio}_cos", None) is None:
             compress_cos, compress_sin = get_cos_and_sin_dsa(
@@ -680,6 +682,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     device=str(self.seqused_q.device))
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         elif self.compressor_ratio == 4:
+            cu_c4_cmp_seqlen_list = _get_cmp_seq_lens(prefill_seq_lens, 4)
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
                 self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
@@ -707,6 +710,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     device=str(self.seqused_q.device))
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         else:
+            cu_c128_cmp_seqlen_list = _get_cmp_seq_lens(
+                prefill_seq_lens, 128)
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
                 self.prefill_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
@@ -875,6 +880,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             compressed_decode_num = mask.sum().item()
             return compressed_decode_num
 
+        def _get_decode_cmp_seq_lens(seq_lens, compress_ratio):
+            if compress_ratio <= 1:
+                return self.cu_seqlens_cmp_kv
+            cmp_seq_lens = seq_lens // compress_ratio
+            return torch.concat(
+                (torch.zeros(1,
+                             dtype=cmp_seq_lens.dtype,
+                             device=cmp_seq_lens.device),
+                 torch.cumsum(cmp_seq_lens, -1)),
+                dim=-1)
+
         if self.decode_ratio_to_sas_metadata.get("compressed_tokens_start_" + str(self.compressor_ratio), None) is None:
             compressed_tokens_start = _get_compressed_decode_token_start(
                 decode_input_positions, self.compressor_ratio)
@@ -923,6 +939,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     device=str(self.seqused_q.device))
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         elif self.compressor_ratio == 4:
+            cu_seqlens_cmp_kv = _get_decode_cmp_seq_lens(
+                self.seq_lens[:self.num_decodes], 4)
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
                 self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
@@ -930,7 +948,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,  # cached
                     cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
+                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[:self.num_decodes],  # cached
                     max_seqlen_q=max_seqlen_q,
@@ -950,6 +968,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     device=str(self.seqused_q.device))
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         else:
+            cu_seqlens_cmp_kv = _get_decode_cmp_seq_lens(
+                self.seq_lens[:self.num_decodes], 128)
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
                 self.decode_ratio_to_sas_metadata[layer_name] = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
                     num_heads_q=n_local_heads,
@@ -957,7 +977,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     head_dim=self.model_config.get_head_size(),
                     cu_seqlens_q=query_start_loc,
                     cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
+                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
                     seqused_kv=self.seq_lens[:self.num_decodes],
                     max_seqlen_q=max_seqlen_q,
@@ -1356,14 +1376,19 @@ class AscendDSAImpl(DSAAttentionImpl):
                 rotary_mode=2,
                 cache_mode=1)
 
-            if compressed_kv.numel() == 0:
+            num_compressed_slots = (
+                compressor_attn_metadata.prefill.slot_mapping.shape[0])
+            if compressed_kv.numel() == 0 or num_compressed_slots == 0:
                 compressed_kv = None
+            else:
+                compressed_kv = compressed_kv[:num_compressed_slots]
 
             # kv_compress_epilog
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                compress_kv_cache,
-                compressor_attn_metadata.prefill.slot_mapping,
-                compressed_kv)
+            if compressed_kv is not None:
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    compress_kv_cache,
+                    compressor_attn_metadata.prefill.slot_mapping,
+                    compressed_kv)
 
         if self.compress_ratio <= 1:
             attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
@@ -1562,10 +1587,14 @@ class AscendDSAImpl(DSAAttentionImpl):
                 rotary_mode=2,
                 cache_mode=1)
             # kv_compress_epilog
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                compress_kv_cache,
-                compressor_attn_metadata.decode.slot_mapping,
-                compressed_kv)
+            num_compressed_slots = (
+                compressor_attn_metadata.decode.slot_mapping.shape[0])
+            if compressed_kv.numel() > 0 and num_compressed_slots > 0:
+                compressed_kv = compressed_kv[:num_compressed_slots]
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    compress_kv_cache,
+                    compressor_attn_metadata.decode.slot_mapping,
+                    compressed_kv)
         if self.compress_ratio <= 1:
             attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
@@ -1726,33 +1755,35 @@ class AscendDSAImpl(DSAAttentionImpl):
         if with_prefill:
             assert indexer_kv_scale_metadata.prefill is not None
             if kv is not None:
-
-                # if torch.distributed.get_rank() == 0:
-                #     print(f"C{self.compress_ratio} Attention decode write kv: {compress_kv_cache=}")
-                #     print(f"C{self.compress_ratio} Attention decode write kv is_contiguous: {compress_kv_cache.is_contiguous()=}")
-                #     print(f"C{self.compress_ratio} Attention decode write kv stride: {compress_kv_cache.stride()=}")
-                #     print(f"C{self.compress_ratio} Attention decode write kv: {compressor_attn_metadata.decode.slot_mapping.unsqueeze(-1)=}")
-                #     print(f"C{self.compress_ratio} Attention decode write kv: {compressed_kv=}")
-
-                torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                    indexer_k_cache,
-                    indexer_kv_scale_metadata.prefill.slot_mapping,
-                    kv)
-                torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                    indexer_scale_cache,
-                    indexer_kv_scale_metadata.prefill.slot_mapping,
-                    kv_scale)
+                num_compressed_slots = (
+                    indexer_kv_scale_metadata.prefill.slot_mapping.shape[0])
+                if num_compressed_slots > 0:
+                    kv = kv[:num_compressed_slots]
+                    kv_scale = kv_scale[:num_compressed_slots]
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_k_cache,
+                        indexer_kv_scale_metadata.prefill.slot_mapping,
+                        kv)
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache,
+                        indexer_kv_scale_metadata.prefill.slot_mapping,
+                        kv_scale)
         else:
             assert indexer_kv_scale_metadata.decode is not None
             if kv is not None:
-                torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                    indexer_k_cache,
-                    indexer_kv_scale_metadata.decode.slot_mapping,
-                    kv)
-                torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                    indexer_scale_cache,
-                    indexer_kv_scale_metadata.decode.slot_mapping,
-                    kv_scale)
+                num_compressed_slots = (
+                    indexer_kv_scale_metadata.decode.slot_mapping.shape[0])
+                if num_compressed_slots > 0:
+                    kv = kv[:num_compressed_slots]
+                    kv_scale = kv_scale[:num_compressed_slots]
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_k_cache,
+                        indexer_kv_scale_metadata.decode.slot_mapping,
+                        kv)
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        indexer_scale_cache,
+                        indexer_kv_scale_metadata.decode.slot_mapping,
+                        kv_scale)
 
         if with_prefill:
             assert indexer_kv_scale_metadata.prefill is not None

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -8,7 +8,7 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import BlockHashList, KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
     SingleTypeKVCacheManager, SlidingWindowManager, FullAttentionManager, spec_manager_map)
-from vllm.v1.kv_cache_interface import KVCacheSpec, AttentionSpec, FullAttentionSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 from vllm.v1.request import Request
 
 from vllm_ascend.core.kv_cache_spec import (CompressAttentionSpec, # --
@@ -32,6 +32,14 @@ class CompressAttentionManager(FullAttentionManager):
         self.compress_ratio = kv_cache_spec.compress_ratio
         self._null_block = block_pool.null_block
 
+    def _num_storage_tokens(self, num_tokens: int) -> int:
+        if self.compress_ratio <= 1:
+            return num_tokens
+        return num_tokens // self.compress_ratio
+
+    def _num_complete_tokens(self, num_tokens: int) -> int:
+        return self._num_storage_tokens(num_tokens)
+
     def get_num_blocks_to_allocate(
         self,
         request_id: str,
@@ -44,8 +52,9 @@ class CompressAttentionManager(FullAttentionManager):
         # speculative decoding (MTP/EAGLE) with linear attention.
         # assert isinstance(self.kv_cache_spec, (CompressAttentionSpec, C4IndexerSpec))
 
-        num_tokens //= self.compress_ratio
-        num_tokens_main_model //= self.compress_ratio
+        num_tokens = self._num_storage_tokens(num_tokens)
+        num_tokens_main_model = self._num_storage_tokens(
+            num_tokens_main_model)
 
         return super().get_num_blocks_to_allocate(request_id, num_tokens,
                                                   new_computed_blocks, total_computed_tokens, num_tokens_main_model)
@@ -85,7 +94,8 @@ class CompressAttentionManager(FullAttentionManager):
         num_total_computed_tokens = (
             num_local_computed_tokens + num_external_computed_tokens
         )
-        num_total_computed_tokens //= self.compress_ratio
+        num_total_computed_tokens = self._num_storage_tokens(
+            num_total_computed_tokens)
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
         if num_skipped_blocks > 0:
@@ -121,8 +131,7 @@ class CompressAttentionManager(FullAttentionManager):
                 cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
             )
             req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) is FullAttentionSpec:
-                self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+            self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
 
     def allocate_new_blocks(self, request_id: str,
@@ -139,9 +148,10 @@ class CompressAttentionManager(FullAttentionManager):
         Returns:
             The new allocated blocks.
         """
-        num_tokens //= self.compress_ratio
+        num_tokens = self._num_storage_tokens(num_tokens)
         ## TODO: check spec decode
-        num_tokens_main_model //= self.compress_ratio
+        num_tokens_main_model = self._num_storage_tokens(
+            num_tokens_main_model)
 
         req_blocks = self.req_to_blocks[request_id]
         num_required_blocks = cdiv(num_tokens, self.block_size)
@@ -152,6 +162,7 @@ class CompressAttentionManager(FullAttentionManager):
             new_blocks = self.block_pool.get_new_blocks(
                 num_new_blocks)
             req_blocks.extend(new_blocks)
+            self.new_block_ids.extend(b.block_id for b in new_blocks)
             return new_blocks
 
     def cache_blocks(self, request: Request, num_tokens: int) -> None:
@@ -163,7 +174,7 @@ class CompressAttentionManager(FullAttentionManager):
             num_tokens: The total number of tokens that need to be cached
                 (including tokens that are already cached).
         """
-        num_tokens //= self.compress_ratio
+        num_tokens = self._num_complete_tokens(num_tokens)
 
         return super().cache_blocks(request, num_tokens)
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -107,9 +107,16 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))
     ),
-    # Whether to use MultiBlockPool for KV cache management
+    # Whether to use MultiBlockPool for KV cache management.
     "USE_MULTI_BLOCK_POOL":
     lambda: bool(int(os.getenv("USE_MULTI_BLOCK_POOL", '0'))),
+    # Whether to use Ascend multi-group KV cache management. This keeps the
+    # upstream hybrid shared_by tensor layout, but uses Ascend's compressed-KV
+    # aware block accounting for DeepSeek-V4.
+    "VLLM_ASCEND_USE_MULTI_GROUPS_KV_CACHE": lambda: bool(
+        int(
+            os.getenv("VLLM_ASCEND_USE_MULTI_GROUPS_KV_CACHE",
+                      os.getenv("USE_MULTI_GROUPS_KV_CACHE", '0')))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -37,7 +37,8 @@ import vllm_ascend.patch.platform.patch_selector # noqa
 if envs.VLLM_ASCEND_BALANCE_SCHEDULING:
     import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
-if envs.USE_MULTI_BLOCK_POOL:
+if (envs.USE_MULTI_BLOCK_POOL
+        or envs.VLLM_ASCEND_USE_MULTI_GROUPS_KV_CACHE):
     import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
     import vllm_ascend.patch.platform.patch_speculative_config  # noqa
     # import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM projectx
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import sys
 from collections.abc import Sequence
+from math import lcm
 
 import vllm
 from vllm.v1.core.block_pool import BlockPool
@@ -22,7 +23,9 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec, FullAttention
 
 from vllm_ascend.core.single_type_kv_cache_manager import \
     get_manager_for_kv_cache_spec
-from math import lcm
+from vllm_ascend import envs
+
+USE_MULTI_GROUPS_KV_CACHE = envs.VLLM_ASCEND_USE_MULTI_GROUPS_KV_CACHE
 
 
 class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
@@ -58,6 +61,8 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             enable_kv_cache_events,
             metrics_collector,
         )
+        self.block_pool._ascend_reuse_freed_blocks_first = (
+            kv_cache_config.needs_kv_cache_zeroing)
 
         # KV cache group indices that get the EAGLE last-block drop.
         self.eagle_group_ids: set[int] = {

--- a/vllm_ascend/patch/platform/patch_kv_cache_interface.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_interface.py
@@ -9,9 +9,13 @@ from typing_extensions import Self
 from vllm.utils.math_utils import round_up
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
     SlidingWindowMLASpec,
     MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
 )
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_manager import KVCacheManager
 
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -202,3 +206,114 @@ def _init_mla_cache_fields(spec: MLAAttentionSpec | SlidingWindowMLASpec):
 
 vllm.v1.kv_cache_interface.MLAAttentionSpec = AscendMLAAttentionSpec
 vllm.v1.kv_cache_interface._init_mla_cache_fields = _init_mla_cache_fields
+
+
+_ORIG_NEEDS_KV_CACHE_ZEROING = KVCacheConfig.needs_kv_cache_zeroing.fget
+
+
+def _needs_kv_cache_zeroing(self: KVCacheConfig) -> bool:
+    assert _ORIG_NEEDS_KV_CACHE_ZEROING is not None
+    if _ORIG_NEEDS_KV_CACHE_ZEROING(self):
+        return True
+
+    for group in self.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, UniformTypeKVCacheSpecs):
+            specs = group_spec.kv_cache_specs.values()
+        else:
+            specs = (group_spec,)
+        if any(
+            isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+            and getattr(spec, "model_version", None) == "svf"
+            and getattr(spec, "compress_ratio", 1) > 1
+            for spec in specs
+        ):
+            return True
+    return False
+
+
+KVCacheConfig.needs_kv_cache_zeroing = property(_needs_kv_cache_zeroing)
+
+
+_ORIG_BLOCK_POOL_GET_NEW_BLOCKS = BlockPool.get_new_blocks
+_ORIG_BLOCK_POOL_FREE_BLOCKS = BlockPool.free_blocks
+_ORIG_KV_CACHE_MANAGER_INIT = KVCacheManager.__init__
+_ORIG_KV_CACHE_MANAGER_TAKE_NEW_BLOCK_IDS = KVCacheManager.take_new_block_ids
+
+
+def _get_new_blocks_with_zero_tracking(self: BlockPool, num_blocks: int):
+    blocks = _ORIG_BLOCK_POOL_GET_NEW_BLOCKS(self, num_blocks)
+    if blocks and getattr(self, "_ascend_track_new_block_ids", False):
+        block_ids = getattr(self, "_ascend_new_block_ids_to_zero", None)
+        if block_ids is None:
+            block_ids = []
+            self._ascend_new_block_ids_to_zero = block_ids
+        block_ids.extend(block.block_id for block in blocks)
+    return blocks
+
+
+def _prepend_free_blocks(free_block_queue, blocks) -> None:
+    if not blocks:
+        return
+
+    old_first_block = free_block_queue.fake_free_list_head.next_free_block
+    if old_first_block is None:
+        raise RuntimeError(
+            "next_free_block of fake_free_list_head should always exist")
+
+    last_block = free_block_queue.fake_free_list_head
+    for block in blocks:
+        block.prev_free_block = last_block
+        last_block.next_free_block = block
+        last_block = block
+
+    last_block.next_free_block = old_first_block
+    old_first_block.prev_free_block = last_block
+    free_block_queue.num_free_blocks += len(blocks)
+
+
+def _free_blocks_with_reuse_first(self: BlockPool, ordered_blocks) -> None:
+    if not getattr(self, "_ascend_reuse_freed_blocks_first", False):
+        return _ORIG_BLOCK_POOL_FREE_BLOCKS(self, ordered_blocks)
+
+    blocks_list = list(ordered_blocks)
+    for block in blocks_list:
+        block.ref_cnt -= 1
+
+    free_blocks = [
+        block for block in blocks_list
+        if block.ref_cnt == 0 and not block.is_null
+    ]
+    free_blocks.sort(key=lambda block: block.block_id)
+    _prepend_free_blocks(self.free_block_queue, free_blocks)
+
+
+def _take_new_block_ids_from_pool(self: BlockPool) -> list[int]:
+    block_ids = getattr(self, "_ascend_new_block_ids_to_zero", None)
+    if not block_ids:
+        return []
+    self._ascend_new_block_ids_to_zero = []
+    return block_ids
+
+
+def _kv_cache_manager_init_with_block_pool_tracking(
+    self: KVCacheManager, *args, **kwargs
+) -> None:
+    _ORIG_KV_CACHE_MANAGER_INIT(self, *args, **kwargs)
+    self.block_pool._ascend_track_new_block_ids = (
+        self.kv_cache_config.needs_kv_cache_zeroing)
+
+
+def _take_new_block_ids_with_block_pool(self: KVCacheManager) -> list[int]:
+    block_ids = _ORIG_KV_CACHE_MANAGER_TAKE_NEW_BLOCK_IDS(self)
+    block_pool = getattr(getattr(self, "coordinator", None), "block_pool", None)
+    if block_pool is not None and hasattr(block_pool, "take_new_block_ids"):
+        block_ids.extend(block_pool.take_new_block_ids())
+    return block_ids
+
+
+BlockPool.get_new_blocks = _get_new_blocks_with_zero_tracking
+BlockPool.free_blocks = _free_blocks_with_reuse_first
+BlockPool.take_new_block_ids = _take_new_block_ids_from_pool
+KVCacheManager.__init__ = _kv_cache_manager_init_with_block_pool_tracking
+KVCacheManager.take_new_block_ids = _take_new_block_ids_with_block_pool

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -12,7 +12,7 @@ from vllm.v1.kv_cache_interface import (KVCacheConfig, KVCacheGroupSpec,
                                         UniformTypeKVCacheSpecs)
 
 from vllm_ascend import envs
-USE_MULTI_GROUPS_KV_CACHE = envs.USE_MULTI_GROUPS_KV_CACHE
+USE_MULTI_GROUPS_KV_CACHE = envs.VLLM_ASCEND_USE_MULTI_GROUPS_KV_CACHE
 
 def _get_kv_cache_groups_uniform_block_size(
     kv_cache_spec: dict[str, KVCacheSpec], ) -> list[KVCacheGroupSpec]:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1471,7 +1471,9 @@ def get_compressed_pos_and_indices(
             compressed_historical_len = num_computed_tokens
             compressed_total_len = (num_computed_tokens + num_scheduled_tokens)
  
-        # The number of new compressed position ids for each request
+        # The number of new compressed position ids for each request. A
+        # compressed KV is produced only when a complete compression window is
+        # available, i.e. floor(total / ratio) - floor(history / ratio).
         num_new_compressed_pos = compressed_total_len - compressed_historical_len
 
         # Core vectorized calculation (no for-loop)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -5,8 +5,29 @@ import torch
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.utils.math_utils import cdiv
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec
+from vllm.v1.kv_cache_interface import KVCacheGroupSpec, UniformTypeKVCacheSpecs
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
+
+
+def _get_kv_cache_group_compress_ratio(
+    kv_cache_group: KVCacheGroupSpec | None,
+) -> int:
+    if kv_cache_group is None or not hasattr(kv_cache_group, "kv_cache_spec"):
+        return 1
+
+    kv_cache_spec = kv_cache_group.kv_cache_spec
+    if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+        compress_ratios = {
+            getattr(spec, "compress_ratio", 1) or 1
+            for spec in kv_cache_spec.kv_cache_specs.values()
+        }
+        if len(compress_ratios) != 1:
+            raise ValueError(
+                "All specs in one UniformTypeKVCacheSpecs group must use "
+                f"the same compress_ratio, got {sorted(compress_ratios)}")
+        return compress_ratios.pop()
+
+    return getattr(kv_cache_spec, "compress_ratio", 1) or 1
 
 
 class BlockTable:
@@ -24,11 +45,7 @@ class BlockTable:
         kv_cache_group: KVCacheGroupSpec = None,
     ):
         self.max_num_reqs = max_num_reqs
-        compress_ratio = 1
-        if kv_cache_group is not None and \
-                hasattr(kv_cache_group, "kv_cache_spec") and \
-                hasattr(kv_cache_group.kv_cache_spec, "compress_ratio"):
-            compress_ratio = kv_cache_group.kv_cache_spec.compress_ratio
+        compress_ratio = _get_kv_cache_group_compress_ratio(kv_cache_group)
         self.max_num_blocks_per_req = max(
             cdiv(max_num_blocks_per_req, compress_ratio), 1)
         self.max_num_batched_tokens = max_num_batched_tokens
@@ -114,11 +131,13 @@ class BlockTable:
 
     def add_row(self, block_ids: list[int], row_idx: int) -> None:
         self.num_blocks_per_row[row_idx] = 0
+        self.block_table.np[row_idx].fill(0)
         self.append_row(block_ids, row_idx)
 
     def move_row(self, src: int, tgt: int) -> None:
         num_blocks = self.num_blocks_per_row[src]
         self.block_table.np[tgt, :num_blocks] = self.block_table.np[src, :num_blocks]
+        self.block_table.np[tgt, num_blocks:].fill(0)
         self.num_blocks_per_row[tgt] = num_blocks
 
     def swap_row(self, src: int, tgt: int) -> None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -458,6 +458,39 @@ class NPUModelRunner(GPUModelRunner):
         self.mamba_state_idx: dict[str, int] = {}
         self._mamba_copy_bufs: mamba_utils.MambaCopyBuffers | None = None
 
+    def _collect_new_block_ids_to_zero(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> list[int]:
+        block_ids = set(scheduler_output.new_block_ids_to_zero or [])
+
+        if not (
+            getattr(self, "use_compress", False)
+            and self.kv_cache_config.needs_kv_cache_zeroing
+        ):
+            return sorted(block_ids)
+
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            if new_req_data.num_computed_tokens != 0:
+                continue
+            for group_block_ids in new_req_data.block_ids:
+                block_ids.update(group_block_ids)
+
+        for new_block_ids in scheduler_output.scheduled_cached_reqs.new_block_ids:
+            if new_block_ids is None:
+                continue
+            for group_block_ids in new_block_ids:
+                block_ids.update(group_block_ids)
+
+        return sorted(block_ids)
+
+    def _update_states(self, scheduler_output: SchedulerOutput) -> None:
+        block_ids = self._collect_new_block_ids_to_zero(scheduler_output)
+        if block_ids:
+            self._zero_block_ids(block_ids)
+            scheduler_output.new_block_ids_to_zero = []
+        super()._update_states(scheduler_output)
+
     @property
     def use_cp(self) -> bool:
         return self.pcp_size * self.dcp_size > 1
@@ -2709,6 +2742,9 @@ class NPUModelRunner(GPUModelRunner):
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)
 
+        if kv_cache_config.needs_kv_cache_zeroing:
+            self._init_kv_zero_meta()
+
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
 
@@ -2730,6 +2766,7 @@ class NPUModelRunner(GPUModelRunner):
         """
         # Initialize the memory buffer for KV cache
         kv_cache_raw_tensors = self._allocate_kv_cache_tensors(kv_cache_config)
+        self._kv_cache_raw_tensors_for_zero = kv_cache_raw_tensors
         # Change the memory buffer to the desired shape
         kv_caches = self._reshape_kv_cache_tensors(kv_cache_config, kv_cache_raw_tensors)
 
@@ -2756,6 +2793,59 @@ class NPUModelRunner(GPUModelRunner):
             num_attn_module = 2 if self.model_config.hf_text_config.model_type == "longcat_flash" else 1
             bind_kv_cache(kv_caches, self.compilation_config.static_forward_context, self.kv_caches, num_attn_module)
         return kv_caches
+
+    def _init_kv_zero_meta(self) -> None:
+        zero_tensors: list[torch.Tensor] = []
+        seen: set[tuple[int, int]] = set()
+        raw_tensors = getattr(self, "_kv_cache_raw_tensors_for_zero", {})
+        layer_kv_cache_spec = self._get_layer_kv_cache_specs(self.kv_cache_config)
+
+        def needs_zero(layer_name: str) -> bool:
+            spec = layer_kv_cache_spec[layer_name]
+            return self.use_compress and isinstance(spec, AttentionSpec)
+
+        for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
+            if not any(needs_zero(layer_name)
+                       for layer_name in kv_cache_tensor.shared_by):
+                continue
+
+            raw_tensor = None
+            for layer_name in kv_cache_tensor.shared_by:
+                candidate = raw_tensors.get(layer_name)
+                if isinstance(candidate, torch.Tensor):
+                    raw_tensor = candidate
+                    break
+            if raw_tensor is None:
+                continue
+
+            key = (raw_tensor.data_ptr(), raw_tensor.storage_offset())
+            if key in seen:
+                continue
+            seen.add(key)
+
+            assert kv_cache_tensor.size % self.kv_cache_config.num_blocks == 0
+            page_size_bytes = kv_cache_tensor.size // self.kv_cache_config.num_blocks
+            zero_tensors.append(
+                raw_tensor[:kv_cache_tensor.size].view(
+                    self.kv_cache_config.num_blocks, page_size_bytes))
+
+        self._npu_kv_zero_tensors = zero_tensors
+        logger.debug("Initialized NPU raw KV block zeroing for %d tensors",
+                     len(zero_tensors))
+
+    def _zero_block_ids(self, block_ids: list[int]) -> None:
+        zero_tensors = getattr(self, "_npu_kv_zero_tensors", None)
+        if not block_ids or not zero_tensors:
+            return
+        block_ids = sorted(set(block_ids))
+        logger.debug("Zeroing NPU KV blocks: ids=%s tensors=%d", block_ids,
+                     len(zero_tensors))
+        torch.npu.synchronize()
+        with torch.no_grad():
+            for tensor in zero_tensors:
+                for block_id in block_ids:
+                    tensor[block_id:block_id + 1].zero_()
+        torch.npu.synchronize()
 
     def _get_layer_kv_cache_specs(self, kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
         layer_kv_cache_spec: dict[str, KVCacheSpec] = {}


### PR DESCRIPTION
## What this PR does / why we need it?

This is the vLLM Ascend side of the first framework-level stabilization plan for GDzhu01/vllm-ascend-deepseekv4#90.

Companion vLLM PR: GDzhu01/vllm-deepseekv4#1
Final minimal root-cause PR: GDzhu01/vllm-ascend-deepseekv4#91

The original DeepSeek-V4-Flash-w8a8-mtp symptom looked like a long-lived KV cache state issue: short outputs were correct, but repeated long requests could start correctly and later lose the output template or drift into repeated `(-1,0)/(0,-1)` text. Before the operator root cause was isolated, this framework-side PR was used to harden the shared hybrid KV path and narrow the problem to physical KV block lifecycle / high physical address behavior.

This PR intentionally preserves vLLM hybrid KV `shared_by` semantics. It does not use the no-share workaround.

## Framework-side changes

- Align compressed MLA / SVF KV accounting with the physical block ranges actually used by the Ascend path.
- Track newly allocated or reused physical KV blocks so the runner can clear raw KV storage before reuse.
- Add raw KV block zeroing for reused physical blocks to avoid stale request state contaminating later decode.
- Prefer compact reuse of freed KV blocks in the first-version mitigation path, reducing high physical block id exposure while debugging.
- Add regression tests for block table resizing, stale block id cleanup, compressed position counting, and raw KV zeroing plumbing.

## Why keep this PR as a reference?

The final accuracy root cause was later found in `npu_scatter_nd_update_v2`: the fp32 sort path can round high strided physical linear addresses above `2^24`, causing adjacent-element writes. That direct root cause is fixed by #91.

Even so, this first-version PR is useful as an engineering reference because it documents and tests the framework-side invariants that made the investigation tractable:

- shared KV tensors must remain shared by `shared_by`;
- compressed KV accounting must match the physical blocks actually touched by kernels;
- reused physical KV storage must not leak stale state into later requests;
- allocator order can hide or expose high physical block id bugs, so it is useful as a diagnostic control.

This PR should be reviewed as the first framework-level mitigation and investigation artifact, not as a replacement for the minimal operator fix in #91.

## Does this PR introduce _any_ user-facing change?

No public API change.

It keeps the shared KV design. It adds framework-side metadata/zeroing behavior for the affected DeepSeek-V4 shared hybrid KV path and keeps the branch-specific KV cache switch already used by this development branch.

## How was this patch tested?

Unit tests used during the first-version validation:

```bash
PYTHONPATH=../gpu018_lf pytest -q tests/ut/patch/platform/test_patch_kv_cache_interface.py
PYTHONPATH=../gpu018_lf pytest -q \
  tests/ut/worker/test_block_table.py::TestBlockTableComputeSlotMapping::test_uniform_type_compress_ratio_resizes_block_table \
  tests/ut/worker/test_block_table.py::TestBlockTableComputeSlotMapping::test_add_row_clears_stale_block_ids \
  tests/ut/test_utils.py::TestUtils::test_get_compressed_pos_counts_complete_windows_only
```

Results observed during investigation: `1 passed`, `3 passed`.

Real-weight investigation context:

- Model: `/models/DeepSeek-V4-Flash-w8a8-mtp`
- Target path: eager, EP enabled, MTP disabled, `max-model-len=8192`
- Repro prompt: repeated choice request via the local curl debug script
- Original bad hash: `26678c03ed21e57a16cb157791933494b2c1254b8ba927392b3ad22b32e209bc`

The later operator-only validation in #91 is the final sign-off for the actual root cause fix.
