### PR TITLE
fix: reuse UB buffers in w4a8 swiglu epilogue to support moe_intermed…

### DIFF
--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/utils/block_epilogue_w4a8post_pertoken_swiglu.hpp
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_kernel/utils/block_epilogue_w4a8post_pertoken_swiglu.hpp
@@ -83,7 +83,6 @@ public:
     CATLASS_DEVICE
     BlockEpilogue(Arch::Resource<ArchTag> const &resource, int32_t n, Params const &params = Params{}) : params(params)
     {
-        // size_t ubOffset = 0;
         ubOffset = 0;
         int32_t eventVMTE2 = 0;
         int32_t eventMTE2V = 0;
@@ -124,23 +123,20 @@ public:
         AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID5);
 #endif
 
-        ubD = resource.ubBuf.template GetBufferByByte<ElementD>(ubOffset);
-        ubOffset += blockN * sizeof(ElementD);
         ubCFp32 = resource.ubBuf.template GetBufferByByte<float>(ubOffset);
-        ubOffset += blockN * sizeof(float) * 2;
-        ubCFp32ChunkN = resource.ubBuf.template GetBufferByByte<float>(ubOffset);
-        ubOffset += ChunkTileLen * sizeof(float);
         ubCFp32ChunkNAbs = resource.ubBuf.template GetBufferByByte<float>(ubOffset);
-        ubOffset += ChunkTileLen * sizeof(float);
-        ubCFp32ChunkNMax = resource.ubBuf.template GetBufferByByte<float>(ubOffset);
-        ubOffset += HalfChunkTileLen * sizeof(float);
         ubQuantS32 = ubCFp32ChunkNAbs.template ReinterpretCast<int32_t>();
         ubQuantF16 = ubCFp32ChunkNAbs.template ReinterpretCast<half>();
+        ubCFp32ChunkNMax = resource.ubBuf.template GetBufferByByte<float>(ubOffset + ChunkTileLen * sizeof(float));
+        sharedTmpBuffer = resource.ubBuf.template GetBufferByByte<uint8_t>(ubOffset + blockN * sizeof(float));
+        ubOffset += blockN * sizeof(float) * 2;
 
+        ubCFp32ChunkN = resource.ubBuf.template GetBufferByByte<float>(ubOffset);
+        ubD = resource.ubBuf.template GetBufferByByte<ElementD>(ubOffset);
         xLowHalfTensor = resource.ubBuf.template GetBufferByByte<half>(ubOffset);
-        ubOffset += ChunkTileLen * sizeof(half);
-        xLowHalfTensor2 = resource.ubBuf.template GetBufferByByte<half>(ubOffset);
-        ubOffset += ChunkTileLen * sizeof(half);
+        xLowHalfTensor2 = resource.ubBuf.template GetBufferByByte<half>(ubOffset + ChunkTileLen * sizeof(half));
+        ubOffset += ChunkTileLen * sizeof(float);
+
         xLowI16Tensor = resource.ubBuf.template GetBufferByByte<int16_t>(ubOffset);
         ubOffset += 128 * sizeof(int16_t);
 
@@ -197,8 +193,6 @@ public:
         uint32_t perCoreData = blockM / epilogueCoreNum;
         uint32_t remainderData = blockM % epilogueCoreNum;
 
-        uint32_t scaleBlock = (perCoreData * sizeof(ElementPerTokenScale) + 31) / 32 * 32;
-        sharedTmpBuffer = resource.ubBuf.template GetBufferByByte<uint8_t>(ubOffset + scaleBlock);
 
         uint32_t tasksForIdx = epilogueCoreIdx < remainderData ? perCoreData + 1 : perCoreData;
         uint32_t loopStartIdx =
@@ -226,7 +220,6 @@ public:
             PipeBarrier<PIPE_V>();
 
             auto &ubAbs = ubCFp32ChunkNAbs;
-            auto &ubMax = ubCFp32ChunkNMax;
             auto &ubReduceMax = ubCFp32ChunkNMax;
             auto &ubOutputTmp = ubAbs;
             auto &sharedUbTmpBuffer = ubReduceMax;
@@ -332,7 +325,7 @@ public:
             // TODO: Check if division affects subsequent data
             AscendC::Div(ubCFp32ChunkN, ubCFp32, ubCFp32ChunkN, ChunkTileLen);
             AscendC::PipeBarrier<PIPE_V>();
-            AscendC::Mul(ubCFp32ChunkN, ubCFp32ChunkN, ubCFp32[ChunkTileLen], ChunkTileLen);
+            AscendC::Mul(ubCFp32ChunkN, ubCFp32ChunkN, ubCFp32[ChunkTileLen], ChunkTileLen); //ubCFp32 finished
 
             // Quantization
             AscendC::PipeBarrier<PIPE_V>();
@@ -351,7 +344,7 @@ public:
             ubPerTokenScaleOutput.SetValue(ubPerTokenScaleOutputOffset, GMubDequantScale / 127.f);
 
             AscendC::WaitFlag<AscendC::HardEvent::S_V>(0);
-            AscendC::Muls(ubOutputTmp, ubCFp32ChunkN, 127.f / GMubDequantScale, ChunkTileLen);
+            AscendC::Muls(ubOutputTmp, ubCFp32ChunkN, 127.f / GMubDequantScale, ChunkTileLen); // ubCFp32ChunkN finished
             AscendC::PipeBarrier<PIPE_V>();
 
             AscendC::Cast(ubQuantS32, ubOutputTmp, AscendC::RoundMode::CAST_RINT, ChunkTileLen);
@@ -418,7 +411,6 @@ private:
     AscendC::LocalTensor<float> ubweighAuxList[UB_STAGES];
     AscendC::LocalTensor<int4b_t> xHighI4TensorList[UB_STAGES];
     AscendC::LocalTensor<int4b_t> xLowI4TensorList[UB_STAGES];
-    AscendC::LocalTensor<half> xHighHalfTensor;
     AscendC::LocalTensor<half> xLowHalfTensor;
     AscendC::LocalTensor<half> xLowHalfTensor2;
     AscendC::LocalTensor<int16_t> xLowI16Tensor;


### PR DESCRIPTION
### What this PR does / why we need it?

修复 w4a8 swiglu epilogue 在 `moe_intermediate_size=3072` 时 UB 空间不足的问题。

原有实现为 `ubD`、`ubCFp32ChunkN`、`xLowHalfTensor`、`xLowHalfTensor2` 各自独立分配 UB，导致总 UB 需求超出硬件限制。本 PR 分析各 tensor 生命周期后将它们复用在同一块 UB 上：
- `ubD` 和 `ubCFp32ChunkN` 共享地址 — 前者在 epilogue 早期使用，后者在量化阶段使用，生命周期不重叠
- `xLowHalfTensor` / `xLowHalfTensor2` 在 `ubCFp32ChunkN` 使用完毕后复用其空间
- `sharedTmpBuffer` 复用 `ubCFp32` 后半部分空间，消除 `scaleBlock` 偏移计算
- 移除未使用的 `xHighHalfTensor` 和冗余的 `ubMax` 引用

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

验证 `moe_intermediate_size=3072` 场景下 UB 不溢出，kernel 正常运行且精度无回退。
