### PR TITLE
[Bugfix][Sample] Align recovered token Triton kernel with PyTorch fallback

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -1,15 +1,21 @@
 import gc
+
 import pytest
 import torch
-from vllm.v1.sample.rejection_sampler import \
-    rejection_random_sample_kernel as original_rejection_random_sample_kernel
+from vllm.triton_utils import triton
+from vllm.v1.sample.rejection_sampler import rejection_random_sample_kernel as original_rejection_random_sample_kernel
 
 from vllm_ascend.ops.triton.reject_sample import (
-    cal_grid_and_block_size, rejection_random_sample_block_verify_kernel,
-    rejection_random_sample_kernel)
+    cal_grid_and_block_size,
+    rejection_random_sample_block_verify_kernel,
+    rejection_random_sample_kernel,
+    sample_recovered_tokens_kernel,
+)
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
-from vllm_ascend.sample.rejection_sampler import \
-    rejection_random_sample_block_verify_pytorch
+from vllm_ascend.sample.rejection_sampler import (
+    rejection_random_sample_block_verify_pytorch,
+    sample_recovered_tokens_pytorch,
+)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -233,3 +239,118 @@ def test_rejection_sampler_block_verify_triton_kernel(
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("is_ngram", [False, True])
+@torch.inference_mode()
+def test_sample_recovered_tokens_triton_ignores_invalid_q(is_ngram):
+    device = 'npu'
+    batch_size = 2
+    max_spec_len = 1
+    vocab_size = 16
+    cu_num_draft_tokens = torch.tensor([1, 2],
+                                       dtype=torch.int32,
+                                       device=device)
+    draft_token_ids = torch.tensor([0, 1], dtype=torch.int64, device=device)
+    target_probs = torch.zeros((2, vocab_size),
+                               dtype=torch.float32,
+                               device=device)
+    draft_probs = None
+    if not is_ngram:
+        draft_probs = torch.zeros((2, vocab_size),
+                                  dtype=torch.float32,
+                                  device=device)
+
+    q = torch.ones((batch_size, vocab_size),
+                   dtype=torch.float32,
+                   device=device)
+    target_probs[0, 3] = 0.1
+    target_probs[0, 7] = 0.9
+    target_probs[1, 4] = 0.9
+    target_probs[1, 8] = 0.2
+    q[0, 3] = 0
+    q[1, 4] = float("inf")
+    inv_q = q.reciprocal()
+    inv_q.masked_fill_(torch.isinf(inv_q), 0)
+
+    output_token_ids_ref = torch.empty_like(draft_token_ids)
+    output_token_ids_triton = torch.empty_like(draft_token_ids)
+    sample_recovered_tokens_pytorch(output_token_ids_ref,
+                                    cu_num_draft_tokens,
+                                    draft_token_ids,
+                                    draft_probs,
+                                    target_probs,
+                                    q,
+                                    vocab_size,
+                                    IS_NGRAM=is_ngram)
+
+    sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
+        output_token_ids_triton,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        inv_q,
+        vocab_size,
+        triton.next_power_of_2(vocab_size),
+        NO_DRAFT_PROBS=is_ngram,
+        SUB_BLOCK=4 * 1024,
+        multibuffer=False)
+    torch.npu.synchronize()
+    assert torch.equal(output_token_ids_ref,
+                       torch.tensor([7, 8],
+                                    dtype=torch.int64,
+                                    device=device))
+    assert torch.equal(output_token_ids_ref, output_token_ids_triton)
+
+
+@torch.inference_mode()
+def test_sample_recovered_tokens_triton_matches_ngram_negative_draft_id():
+    device = 'npu'
+    batch_size = 1
+    max_spec_len = 1
+    vocab_size = 8
+    cu_num_draft_tokens = torch.tensor([1],
+                                       dtype=torch.int32,
+                                       device=device)
+    draft_token_ids = torch.tensor([-1], dtype=torch.int64, device=device)
+    target_probs = torch.zeros((1, vocab_size),
+                               dtype=torch.float32,
+                               device=device)
+    target_probs[0, -1] = 10
+    target_probs[0, 3] = 1
+
+    q = torch.ones((batch_size, vocab_size),
+                   dtype=torch.float32,
+                   device=device)
+    inv_q = q.reciprocal()
+
+    output_token_ids_ref = torch.empty_like(draft_token_ids)
+    output_token_ids_triton = torch.empty_like(draft_token_ids)
+    sample_recovered_tokens_pytorch(output_token_ids_ref,
+                                    cu_num_draft_tokens,
+                                    draft_token_ids,
+                                    None,
+                                    target_probs,
+                                    q,
+                                    vocab_size,
+                                    IS_NGRAM=True)
+
+    sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
+        output_token_ids_triton,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        None,
+        target_probs,
+        inv_q,
+        vocab_size,
+        triton.next_power_of_2(vocab_size),
+        NO_DRAFT_PROBS=True,
+        SUB_BLOCK=4 * 1024,
+        multibuffer=False)
+    torch.npu.synchronize()
+    assert torch.equal(output_token_ids_ref,
+                       torch.tensor([3],
+                                    dtype=torch.int64,
+                                    device=device))
+    assert torch.equal(output_token_ids_ref, output_token_ids_triton)

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -243,7 +243,7 @@ def sample_recovered_tokens_kernel(
     draft_token_ids_ptr,  # [num_tokens]
     draft_probs_ptr,  # [num_tokens, vocab_size] or None
     target_probs_ptr,  # [num_tokens, vocab_size]
-    q_ptr,  # [batch_size, vocab_size]
+    inv_q_ptr,  # [batch_size, vocab_size]
     vocab_size,
     PADDED_VOCAB_SIZE: tl.constexpr,
     NO_DRAFT_PROBS: tl.constexpr,
@@ -260,26 +260,24 @@ def sample_recovered_tokens_kernel(
         return
 
     loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
-    global_recovered_id = -1
+    global_recovered_id = 0
     global_max_p = -1.0
     if NO_DRAFT_PROBS:
         draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
+        draft_token_id = tl.where(draft_token_id < 0, draft_token_id + vocab_size, draft_token_id)
         for loop_i in range(loop):
             vocab_start = loop_i * SUB_BLOCK
             vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+            vocab_mask = vocab_offset < vocab_size
             prob = tl.load(
                 target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-                mask=vocab_offset < vocab_size,
+                mask=vocab_mask & (vocab_offset != draft_token_id),
                 other=0,
             )
-            # Temporarily zero out the probability of the draft token.
-            # This is essentially the same as target_prob - draft_prob, except that
-            # n-gram does not have draft_prob. We regard it as 1.
-            prob = tl.where(vocab_offset == draft_token_id, 0, prob)
-            q = tl.load(
-                q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=float("-inf")
+            inv_q = tl.load(
+                inv_q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_mask, other=0.0
             )
-            new_p = prob / q
+            new_p = tl.where((inv_q > 0) & vocab_mask, prob * inv_q, -1.0)
             recovered_id = tl.argmax(new_p, axis=-1)
             max_p = get_element(new_p, (recovered_id,))
             if max_p > global_max_p:
@@ -301,10 +299,10 @@ def sample_recovered_tokens_kernel(
             # NOTE(woosuk): We don't need `prob = prob / tl.sum(prob)` here because
             # `tl.argmax` will select the maximum value.
 
-            q = tl.load(
-                q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=float("-inf")
+            inv_q = tl.load(
+                inv_q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=0.0
             )
-            new_p = prob / q
+            new_p = tl.where((inv_q > 0) & (vocab_offset < vocab_size), prob * inv_q, -1.0)
             recovered_id = tl.argmax(new_p, axis=-1)
             max_p = get_element(new_p, (recovered_id,))
             if max_p > global_max_p:

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -337,6 +337,8 @@ def sample_recovered_tokens(
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
     if HAS_TRITON:
+        q.reciprocal_()
+        q.masked_fill_(torch.isinf(q), 0)
         sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
             recovered_token_ids,
             cu_num_draft_tokens,


### PR DESCRIPTION
## What this PR does / why we need it?

修复 DeepSeek V4 Flash W8A8 + MTP/speculative decoding 场景下 `sample_recovered_tokens_kernel` 与 PyTorch fallback 不一致的问题。该不一致会影响 recovered token 采样，长输出下可能表现为卡死、随机退化或无限复读。

本 PR 聚焦 `sample_recovered_tokens_pytorch` golden 对齐，包含两个最小修复：

1. `q == 0/inf` 数值防护
   - PyTorch fallback 会屏蔽 `q == 0` 和 `inf` 的位置。
   - Triton 原实现直接执行 `prob / q`，当 `q == 0` 时会产生 `inf` 并被 `argmax` 错误选中。
   - 修复为 Python wrapper 中预计算 safe `inv_q`，Triton kernel 使用 `prob * inv_q`，并屏蔽 `inv_q <= 0`。

2. ngram 路径负 draft token id 对齐
   - PyTorch fallback 的 `modified_target_probs[token_indices, draft_token_ids] = 0` 遵循 PyTorch 负索引语义，`draft_token_ids == -1` 会屏蔽最后一个 vocab。
   - Triton 原实现用 `vocab_offset != draft_token_id`，当 draft id 为 `-1` 时不会屏蔽任何 vocab，可能错误选中最后一个 token。
   - 修复为 ngram 分支先将负 draft id 映射为 `draft_token_id + vocab_size`，与 PyTorch fallback 对齐。

此外，ngram 分支不再原地修改 `target_probs`，而是在 load mask 中直接排除 draft token。

Closes #101

## Does this PR introduce _any_ user-facing change?

No. 该修改只修复 reject sampler 内部 recovered token 采样路径的数值和索引语义，不改变用户 API 或启动参数。

## How was this patch tested?

```bash
pytest -q tests/ut/sample/test_rejection_sampler.py
ASCEND_RT_VISIBLE_DEVICES=0 pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
ruff check vllm_ascend/ops/triton/reject_sample.py vllm_ascend/sample/rejection_sampler.py tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
```

结果：

- `tests/ut/sample/test_rejection_sampler.py`: 6 passed
- `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py`: 28 passed
- `ruff check`: passed

额外验证：

- 真实 vocab size 151936、batch size 32、循环 200 次并周期性注入 `q == 0/inf` 的算子压力测试正常完成。
- 30 个随机 ngram 小矩阵，允许 `draft_token_ids` 在 `[-1, vocab)` 内随机出现，Triton 与 PyTorch fallback 完全一致。