### PR TITLE
Fix response_format crash with recompute MTP KV consumer

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -141,11 +141,7 @@ class RecomputeScheduler(Scheduler):
             # Fill in placeholder tokens to enable full graph compatibility. Without
             # placeholders, graph matching may fail, forcing eager mode execution.
             if self.is_mtp_kv_consumer:
-                #padding_token_id = (
-                #    request.sampling_params.eos_token_id if request.sampling_params.eos_token_id is not None else PLACEHOLDER_TOKEN_ID
-                #)
-                padding_token_id = 0
-                request.spec_token_ids = [padding_token_id] * self.num_spec_tokens
+                request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.log_stats:


### PR DESCRIPTION
## 背景

Fixes #100。

DeepSeek V4 Flash 在 `MooncakeHybridConnector + MTP/spec decode + recompute_scheduler_enable=true` 同时开启时，`response_format` 请求会触发 structured output assert，返回 HTTP 500 并导致 EngineCore fatal。

## 根因

`RecomputeScheduler.add_request()` 在 MTP KV consumer 场景下为了保持 full graph 形态，会预填充 `request.spec_token_ids`。原实现使用 token `0` 作为占位：

```python
padding_token_id = 0
request.spec_token_ids = [padding_token_id] * self.num_spec_tokens
```

该值会进入 `scheduled_spec_decode_tokens`，structured output 在生成 bitmask 前会用这些 spec token 推进 grammar FSM。JSON grammar 拒绝 token `0` 后触发：

```text
assert accepted, (token, req_id, scheduled_spec_decode_tokens)
AssertionError: (0, ..., {...: [0]})
```

## 修改

只做最小修复：将人工占位 spec token 改为 vLLM 已约定的 `PLACEHOLDER_TOKEN_ID`。

```python
request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
```

`PLACEHOLDER_TOKEN_ID == -1` 会被 structured output 路径识别为 padding，不会作为真实 token 推进 grammar。

## 验证

已在真实 DeepSeek V4 Flash 权重上验证原最小失败条件：

- `MooncakeHybridConnector`
- MTP：`--speculative-config '{"num_speculative_tokens":1,"method":"mtp"}'`
- recompute：`--additional-config '{"recompute_scheduler_enable":true}'`
- `FULL_DECODE_ONLY`

结果：

- plain chat：HTTP 200
- `response_format: {"type":"json_object"}`：HTTP 200
- `response_format: {"type":"json_schema"}`：HTTP 200
- Alice/30 `json_object` 示例：HTTP 200，返回 `{"name": "Alice", "age": 30}`
- 服务日志未再出现 `AssertionError`、`Failed to advance FSM` 或 `EngineDeadError`

本地静态检查：

```bash
python -m py_compile vllm_ascend/core/recompute_scheduler.py
```
