### PR TITLE
Fix mtp precision with large num_speculative_tokens

### DIFF
--- a/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
+++ b/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
@@ -729,6 +729,32 @@ __aicore__ inline void CompressorBlockVectorPerf<COMP>::SaveState(const LocalTen
 {
     if constexpr (COMP::coff == COFF::OVERLAP) {
         uint32_t coff = static_cast<uint32_t>(COMP::coff);
+
+        if (sliceInfo.dealTcSize > 1) {
+            // 后续的状态保存逻辑只覆盖尾侧窗口。对于批量 verifier 调用，
+            // 还需要持久化当前处理的第一个块，确保任意可能被接受的前缀
+            // 都能得到与串行逐 token 压缩一致的 state
+            uint32_t firstCopySeqCnt = constInfo_.cmpRatio - sliceInfo.headHolderSeqCnt;
+            if (firstCopySeqCnt > sliceInfo.validSeqCnt) {
+                firstCopySeqCnt = sliceInfo.validSeqCnt;
+            }
+
+            uint64_t startSeqIdx = sliceInfo.bStartPos + sliceInfo.sIdx;
+            uint64_t endSeqIdx = startSeqIdx + firstCopySeqCnt;
+            uint64_t leftSrcBaseOffset =
+                (sliceInfo.preValidSeqCnt + sliceInfo.preTailHolderSeqCnt + sliceInfo.headHolderSeqCnt) *
+                coff * dDealSize;
+            uint64_t rightSrcBaseOffset = sliceInfo.headHolderSeqCnt * coff * dDealSize + dDealSize;
+            WriteToCacheState(kvStateGm_, kvBlockTableGm_, kvLocal[leftSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx, dDealSize);
+            WriteToCacheState(scoreStateGm_, scoreBlockTableGm_, scoreLocal[leftSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx, dDealSize);
+            WriteToCacheState(kvStateGm_, kvBlockTableGm_, kvLocal[rightSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx + constInfo_.headDim, dDealSize);
+            WriteToCacheState(scoreStateGm_, scoreBlockTableGm_, scoreLocal[rightSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx + constInfo_.headDim, dDealSize);
+        }
+
         // 存右边
         if (sliceInfo.sIdx + sliceInfo.validSeqCnt == sliceInfo.bSeqUsed) {
             uint32_t copySeqCnt = constInfo_.cmpRatio - sliceInfo.tailHolderSeqCnt;

--- a/tests/ut/ops/test_moe_runtime_args.py
+++ b/tests/ut/ops/test_moe_runtime_args.py
@@ -211,6 +211,41 @@ class TestMoERuntimeArgs(unittest.TestCase):
         self.assertEqual(mlp_compute_input.quant.mxfp.per_token_scale_dtype, torch.float16)
         self.assertFalse(mlp_compute_input.quant.mxfp.use_bf16)
 
+    def test_build_mlp_compute_input_enables_w4a8_fusion_only_with_dynamic_eplb(self):
+        token_dispatch_output = MoETokenDispatchOutput(
+            hidden_states=torch.randn(4, 8, dtype=torch.bfloat16),
+            group_list=torch.tensor([2, 2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=torch.randn(4, 1),
+            combine_metadata=MoEAllGatherCombineMetadata(
+                topk_weights=torch.randn(2, 2),
+                expanded_row_idx=torch.arange(4, dtype=torch.int32),
+                restore_shape=torch.Size([2, 8]),
+            ),
+        )
+
+        for dynamic_eplb, expected_fusion in ((True, True), (False, False)):
+            with self.subTest(dynamic_eplb=dynamic_eplb):
+                fused_experts_input = build_fused_experts_input(
+                    hidden_states=torch.randn(2, 8, dtype=torch.bfloat16),
+                    topk_weights=torch.randn(2, 2),
+                    topk_ids=torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
+                    w1=torch.randn(2, 8, 16),
+                    w2=torch.randn(2, 16, 8),
+                    quant_type=QuantType.W4A8,
+                    dynamic_eplb=dynamic_eplb,
+                    w1_scale=[torch.randn(1)],
+                    w2_scale=[torch.randn(1)],
+                )
+
+                mlp_compute_input = build_mlp_compute_input(
+                    fused_experts_input=fused_experts_input,
+                    token_dispatch_output=token_dispatch_output,
+                    use_fusion_ops=True,
+                )
+
+                self.assertEqual(mlp_compute_input.fusion, expected_fusion)
+
     def test_build_fused_experts_input_constructs_internal_mxfp_leaf_from_primitives(self):
         fused_experts_input = build_fused_experts_input(
             hidden_states=torch.randn(2, 8, dtype=torch.bfloat16),

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -250,7 +250,7 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if bias1 is not None and bias1[0].numel() > 0 and fusion and not dynamic_eplb and enable_custom_op():
+        if bias1 is not None and bias1[0].numel() > 0 and not dynamic_eplb and enable_custom_op():
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,
                 weight=w1,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -251,6 +251,7 @@ def quant_apply_mlp(
             _output_dtype = torch.bfloat16
 
         if bias1 is not None and bias1[0].numel() > 0 and not dynamic_eplb and enable_custom_op():
+            print(f'hidden_states shape: {hidden_states.shape}, w1_shape: {w1[0].shape}, group_list shape: {group_list.shape},w1_scale shape: {w1_scale[0].shape}, weight_assist_matrix shape: {bias1.shape}')
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,
                 weight=w1,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -250,7 +250,20 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if _custom_gmm_swiglu_enabled(fusion, dynamic_eplb) and not use_mxfp_quant:
+        if bias1 is not None and bias1[0].numel() > 0 and _custom_gmm_swiglu_enabled(fusion, dynamic_eplb):
+            hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
+                x=hidden_states,
+                weight=w1,
+                weight_scale=w1_scale,
+                x_scale=pertoken_scale,
+                group_list=cumsum_group_list(group_list, group_list_type, 0),
+                weight_assist_matrix=bias1,
+                dequant_mode=1,
+                swiglu_limit=swiglu_limit,
+            )
+            if quantized_hidden_states is not None:
+                dispose_tensor(quantized_hidden_states)
+        elif _custom_gmm_swiglu_enabled(fusion, dynamic_eplb) and not use_mxfp_quant:
             # gmm1: gate_up_proj & act_fn: swiglu
             hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
                 x=hidden_states,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -250,7 +250,7 @@ def quant_apply_mlp(
             # TODO w4a8 scene: dynamic acquisition of dtype in the future
             _output_dtype = torch.bfloat16
 
-        if bias1 is not None and bias1[0].numel() > 0 and _custom_gmm_swiglu_enabled(fusion, dynamic_eplb):
+        if bias1 is not None and bias1[0].numel() > 0 and fusion and not dynamic_eplb and enable_custom_op():
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
                 x=hidden_states,
                 weight=w1,

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -220,7 +220,11 @@ def build_mlp_compute_input(
         topk_scales=token_dispatch_output.topk_scales,
         weights=fused_experts_input.weights,
         quant=fused_experts_input.quant,
-        fusion=fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8) and use_fusion_ops,
+        fusion=(
+            fused_experts_input.quant.quant_type in (QuantType.W8A8, QuantType.MXFP8)
+            or (fused_experts_input.quant.quant_type == QuantType.W4A8 and fused_experts_input.dynamic_eplb)
+        )
+        and use_fusion_ops,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -21,6 +21,69 @@ from vllm_ascend.ops.triton.reject_sample import (
 from vllm_ascend.sample.sampler import apply_top_k_top_p
 
 
+FORCED_TOKEN_ACCEPTANCE_RATE: float | None = None
+
+
+def force_token_acceptance_sample(
+    output_token_ids: torch.Tensor,
+    draft_token_ids: torch.Tensor,
+    num_draft_tokens: list[int],
+    max_spec_len: int,
+    cu_num_draft_tokens: torch.Tensor,
+    target_logits: torch.Tensor,
+    bonus_token_ids: torch.Tensor,
+    acceptance_rate: float,
+) -> torch.Tensor:
+    batch_size = len(num_draft_tokens)
+    device = output_token_ids.device
+    cu_num_draft_tokens = cu_num_draft_tokens.to(dtype=torch.long)
+    cu_start = torch.cat([
+        torch.zeros(1, dtype=torch.long, device=device),
+        cu_num_draft_tokens[:-1],
+    ])
+    num_draft_tokens_tensor = cu_num_draft_tokens - cu_start
+
+    positions = torch.arange(max_spec_len, device=device)[None, :]
+    valid_mask = positions < num_draft_tokens_tensor[:, None]
+    accept_mask = torch.rand(
+        (batch_size, max_spec_len),
+        device=device,
+    ) < acceptance_rate
+    num_accepted_tokens = (accept_mask & valid_mask).sum(dim=1)
+
+    if draft_token_ids.numel() > 0 and max_spec_len > 0:
+        global_token_indices = cu_start[:, None] + positions
+        global_token_indices = global_token_indices.clamp(
+            max=draft_token_ids.shape[0] - 1,
+        )
+        draft_tokens = draft_token_ids[global_token_indices]
+        accepted_prefix_mask = positions < num_accepted_tokens[:, None]
+        output_token_ids[:, :max_spec_len] = torch.where(
+            accepted_prefix_mask & valid_mask,
+            draft_tokens.to(output_token_ids.dtype),
+            output_token_ids[:, :max_spec_len],
+        )
+
+    row_indices = torch.arange(batch_size, device=device)
+    reject_mask = num_accepted_tokens < num_draft_tokens_tensor
+    target_token_ids = target_logits.argmax(dim=-1)
+    reject_rows = row_indices[reject_mask]
+    reject_cols = num_accepted_tokens[reject_mask]
+    reject_global_indices = cu_start[reject_mask] + reject_cols
+    output_token_ids[reject_rows, reject_cols] = target_token_ids[
+        reject_global_indices
+    ].to(output_token_ids.dtype)
+
+    bonus_mask = ~reject_mask
+    bonus_rows = row_indices[bonus_mask]
+    bonus_cols = num_draft_tokens_tensor[bonus_mask]
+    output_token_ids[bonus_rows, bonus_cols] = bonus_token_ids.view(-1)[
+        bonus_mask
+    ].to(output_token_ids.dtype)
+
+    return output_token_ids
+
+
 def apply_sampling_constraints(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     cu_num_draft_tokens: torch.Tensor,  # [batch_size]
@@ -122,6 +185,18 @@ def rejection_sample(
         device=device,
     )
     output_token_ids.fill_(PLACEHOLDER_TOKEN_ID)
+
+    if FORCED_TOKEN_ACCEPTANCE_RATE is not None:
+        return force_token_acceptance_sample(
+            output_token_ids,
+            draft_token_ids,
+            num_draft_tokens,
+            max_spec_len,
+            cu_num_draft_tokens,
+            target_logits,
+            bonus_token_ids,
+            FORCED_TOKEN_ACCEPTANCE_RATE,
+        )
 
     if sampling_metadata.all_greedy:
         is_greedy = None

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -22,6 +22,9 @@ from vllm_ascend.sample.sampler import apply_top_k_top_p
 
 
 FORCED_TOKEN_ACCEPTANCE_RATE: float | None = None
+FORCED_TOKEN_ACCEPTANCE_RATE_SCALE = 1000
+FORCED_TOKEN_ACCEPTANCE_RATE_STRIDE = 997
+_forced_token_acceptance_offset = 0
 
 
 def force_token_acceptance_sample(
@@ -34,6 +37,7 @@ def force_token_acceptance_sample(
     bonus_token_ids: torch.Tensor,
     acceptance_rate: float,
 ) -> torch.Tensor:
+    global _forced_token_acceptance_offset
     batch_size = len(num_draft_tokens)
     device = output_token_ids.device
     cu_num_draft_tokens = cu_num_draft_tokens.to(dtype=torch.long)
@@ -44,12 +48,30 @@ def force_token_acceptance_sample(
     num_draft_tokens_tensor = cu_num_draft_tokens - cu_start
 
     positions = torch.arange(max_spec_len, device=device)[None, :]
-    valid_mask = positions < num_draft_tokens_tensor[:, None]
-    accept_mask = torch.rand(
-        (batch_size, max_spec_len),
-        device=device,
-    ) < acceptance_rate
-    num_accepted_tokens = (accept_mask & valid_mask).sum(dim=1)
+    acceptance_rate_units = round(
+        acceptance_rate * FORCED_TOKEN_ACCEPTANCE_RATE_SCALE)
+    acceptance_rate_units = max(
+        0, min(FORCED_TOKEN_ACCEPTANCE_RATE_SCALE, acceptance_rate_units))
+    scaled_accepted_tokens = num_draft_tokens_tensor * acceptance_rate_units
+    num_accepted_tokens = (
+        scaled_accepted_tokens // FORCED_TOKEN_ACCEPTANCE_RATE_SCALE)
+    fractional_acceptance = (
+        scaled_accepted_tokens
+        - num_accepted_tokens * FORCED_TOKEN_ACCEPTANCE_RATE_SCALE)
+    row_offsets = (
+        torch.arange(batch_size, device=device)
+        + _forced_token_acceptance_offset)
+    deterministic_slots = (
+        row_offsets * FORCED_TOKEN_ACCEPTANCE_RATE_STRIDE
+    ) % FORCED_TOKEN_ACCEPTANCE_RATE_SCALE
+    add_fractional_token = (
+        deterministic_slots < fractional_acceptance)
+    num_accepted_tokens += (
+        add_fractional_token
+        & (num_accepted_tokens < num_draft_tokens_tensor)).to(torch.long)
+    _forced_token_acceptance_offset = (
+        _forced_token_acceptance_offset + batch_size
+    ) % FORCED_TOKEN_ACCEPTANCE_RATE_SCALE
 
     if draft_token_ids.numel() > 0 and max_spec_len > 0:
         global_token_indices = cu_start[:, None] + positions
@@ -59,7 +81,7 @@ def force_token_acceptance_sample(
         draft_tokens = draft_token_ids[global_token_indices]
         accepted_prefix_mask = positions < num_accepted_tokens[:, None]
         output_token_ids[:, :max_spec_len] = torch.where(
-            accepted_prefix_mask & valid_mask,
+            accepted_prefix_mask,
             draft_tokens.to(output_token_ids.dtype),
             output_token_ids[:, :max_spec_len],
         )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -127,6 +127,7 @@ from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.patch.worker.patch_draft_quarot import patch_load_weights
 from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
 from vllm_ascend.quantization.utils import enable_fa_quant
+from vllm_ascend.sample import rejection_sampler as ascend_rejection_sampler
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
@@ -1664,12 +1665,25 @@ class NPUModelRunner(GPUModelRunner):
 
         if lmhead_tp_enable() and logits is not None:
             logits = logits[: len(spec_decode_metadata.logits_indices)]
-        sampler_output = self.rejection_sampler(
-            spec_decode_metadata,
-            None,  # draft_probs
-            logits,
-            sampling_metadata,
+        forced_acceptance_rate = None
+        if self.speculative_config and self.speculative_config.method in (
+            "mtp",
+            "deepseek_mtp",
+        ):
+            forced_acceptance_rate = 0.7
+        old_forced_acceptance_rate = (
+            ascend_rejection_sampler.FORCED_TOKEN_ACCEPTANCE_RATE
         )
+        ascend_rejection_sampler.FORCED_TOKEN_ACCEPTANCE_RATE = forced_acceptance_rate
+        try:
+            sampler_output = self.rejection_sampler(
+                spec_decode_metadata,
+                None,  # draft_probs
+                logits,
+                sampling_metadata,
+            )
+        finally:
+            ascend_rejection_sampler.FORCED_TOKEN_ACCEPTANCE_RATE = old_forced_acceptance_rate
         return sampler_output
 
     # TODO: remove this func after eagle_proposer is refactored and


### PR DESCRIPTION
修复高MTP精度问题：
在批量 verifier 场景下，当一次处理多个 Tc 块时，额外将当前 slice 的首个有效块的 left/right state 写回 kv/score cache。这样任意被接受的前缀都能恢复到与串行逐 token 压缩一致的状态，避免后续逻辑只保存尾侧窗口导致首块 state 缺失。