### PR TITLE
Fix the precision of the hc_pre_v2 operator

### DIFF
--- a/csrc/moe/hc_pre/op_host/hc_pre_tiling.cpp
+++ b/csrc/moe/hc_pre/op_host/hc_pre_tiling.cpp
@@ -51,6 +51,7 @@ constexpr int64_t ITER_TIMES_ATTR_IDX = 1;
 constexpr int64_t HC_EPS_ATTR_IDX = 2;
 constexpr int64_t NORM_EPS_ATTR_IDX = 3;
 constexpr int64_t DEFAULT_ITER_TIMES = 20;
+constexpr int64_t BS_SPLIT_THRESHOLD = 128;
 }
 
 ge::graphStatus HcPreTiling::GetPlatformInfo()
@@ -142,9 +143,9 @@ ge::graphStatus HcPreTiling::GetShapeAttrsInfoInner()
 
 ge::graphStatus HcPreTiling::CalcMKSplitCoreMembasePart2Tiling() 
 {
-    rowOfFormerBlock_ = CeilDiv(bs_, static_cast<int64_t>(aivCoreNum_));
-    usedAivCoreNums_ = std::min(CeilDiv(bs_, rowOfFormerBlock_), static_cast<int64_t>(aivCoreNum_));
-    rowOfTailBlock_ = bs_ - (usedAivCoreNums_ - 1) * rowOfFormerBlock_;
+    rowOfFormerBlock_ = CeilDiv(curBsSplit_, static_cast<int64_t>(aivCoreNum_));
+    usedAivCoreNums_ = std::min(CeilDiv(curBsSplit_, rowOfFormerBlock_), static_cast<int64_t>(aivCoreNum_));
+    rowOfTailBlock_ = curBsSplit_ - (usedAivCoreNums_ - 1) * rowOfFormerBlock_;
 
     int64_t minRowPerCore = 1;
     int64_t rowOnceLoop = std::min(rowOfFormerBlock_, minRowPerCore);
@@ -380,13 +381,92 @@ ge::graphStatus HcPreTiling::CalcMembaseOpTiling()
     return ge::GRAPH_SUCCESS;
 }
 
+ge::graphStatus HcPreTiling::CalcBsSplit()
+{
+    tailBs_ = bs_;
+    curBsSplit_ = bs_;
+    if (bs_ > BS_SPLIT_THRESHOLD) {
+        bsLoop_ = CeilDiv(bs_, BS_SPLIT_THRESHOLD);
+        tailBs_ = bs_ % BS_SPLIT_THRESHOLD;
+        if (tailBs_ == 0) {
+            tailBs_ = BS_SPLIT_THRESHOLD;
+        }
+        curBsSplit_ = BS_SPLIT_THRESHOLD;
+    }
+    tilingData_.set_bsSplitThreshold(BS_SPLIT_THRESHOLD);
+    tilingData_.set_bsLoop(bsLoop_);
+    tilingData_.set_tailBs(tailBs_);
+    tilingData_.set_curBsSplit(curBsSplit_);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus HcPreTiling::CalcTailBsTiling()
+{
+    if (tailBs_ == BS_SPLIT_THRESHOLD || tailBs_ == bs_) {
+        tilingData_.set_tailBsRowOfFormerBlock(tilingData_.get_rowOfFormerBlock());
+        tilingData_.set_tailBsRowOfTailBlock(tilingData_.get_rowOfTailBlock());
+        tilingData_.set_tailBsRowLoopOfFormerBlock(tilingData_.get_rowLoopOfFormerBlock());
+        tilingData_.set_tailBsRowLoopOfTailBlock(tilingData_.get_rowLoopOfTailBlock());
+        tilingData_.set_tailBsUsedCoreNum(tilingData_.get_secondUsedCoreNum());
+        tilingData_.set_tailBsRowFactor(tilingData_.get_stage2RowFactor());
+        tilingData_.set_tailBsTailRowFactorOfFormerBlock(tilingData_.get_tailRowFactorOfFormerBlock());
+        tilingData_.set_tailBsTailRowFactorOfTailBlock(tilingData_.get_tailRowFactorOfTailBlock());
+        tilingData_.set_tailBsML1Size(tilingData_.get_mL1Size());
+        tilingData_.set_tailBsKL1Size(tilingData_.get_kL1Size());
+        tilingData_.set_tailBsMultCoreSplitMSize(tilingData_.get_multCoreSplitMSize());
+        tilingData_.set_tailBsCubeBlockDimM(tilingData_.get_cubeBlockDimM());
+        return ge::GRAPH_SUCCESS;
+    }
+
+    uint64_t tailMDimNum = std::min(aicCoreNum_, static_cast<uint64_t>(CeilDiv(tailBs_, M_L1_MAX_SIZE)));
+    uint64_t tailSingleCoreM = RoundUp(CeilDiv(tailBs_, tailMDimNum), AscendC::BLOCK_CUBE);
+
+    tailBsCubeBlockDimM_ = static_cast<int64_t>(tailMDimNum);
+    tailBsMultCoreSplitMSize_ = static_cast<int64_t>(tailSingleCoreM);
+    tailBsML1Size_ = std::min(M_L1_MAX_SIZE, tailSingleCoreM);
+    tailBsKL1Size_ = std::min(A_L1_SIZE / tailSingleCoreM, static_cast<uint64_t>(K_L1_MAX_SIZE)) / 128 * 128;
+
+    tailBsRowOfFormerBlock_ = CeilDiv(tailBs_, static_cast<int64_t>(aivCoreNum_));
+    tailBsUsedCoreNum_ = std::min(CeilDiv(tailBs_, tailBsRowOfFormerBlock_), static_cast<int64_t>(aivCoreNum_));
+    tailBsRowOfTailBlock_ = tailBs_ - (tailBsUsedCoreNum_ - 1) * tailBsRowOfFormerBlock_;
+
+    int64_t minRowPerCore = 1;
+    tailBsRowFactor_ = std::min(tailBsRowOfFormerBlock_, minRowPerCore);
+
+    tailBsRowLoopOfFormerBlock_ = CeilDiv(tailBsRowOfFormerBlock_, tailBsRowFactor_);
+    tailBsRowLoopOfTailBlock_ = CeilDiv(tailBsRowOfTailBlock_, tailBsRowFactor_);
+    tailBsTailRowFactorOfFormerBlock_ = tailBsRowOfFormerBlock_ % tailBsRowFactor_ == 0 ?
+                                         tailBsRowFactor_ : tailBsRowOfFormerBlock_ % tailBsRowFactor_;
+    tailBsTailRowFactorOfTailBlock_ = tailBsRowOfTailBlock_ % tailBsRowFactor_ == 0 ?
+                                       tailBsRowFactor_ : tailBsRowOfTailBlock_ % tailBsRowFactor_;
+
+    tilingData_.set_tailBsRowOfFormerBlock(tailBsRowOfFormerBlock_);
+    tilingData_.set_tailBsRowOfTailBlock(tailBsRowOfTailBlock_);
+    tilingData_.set_tailBsRowLoopOfFormerBlock(tailBsRowLoopOfFormerBlock_);
+    tilingData_.set_tailBsRowLoopOfTailBlock(tailBsRowLoopOfTailBlock_);
+    tilingData_.set_tailBsUsedCoreNum(tailBsUsedCoreNum_);
+    tilingData_.set_tailBsRowFactor(tailBsRowFactor_);
+    tilingData_.set_tailBsTailRowFactorOfFormerBlock(tailBsTailRowFactorOfFormerBlock_);
+    tilingData_.set_tailBsTailRowFactorOfTailBlock(tailBsTailRowFactorOfTailBlock_);
+    tilingData_.set_tailBsML1Size(tailBsML1Size_);
+    tilingData_.set_tailBsKL1Size(tailBsKL1Size_);
+    tilingData_.set_tailBsMultCoreSplitMSize(tailBsMultCoreSplitMSize_);
+    tilingData_.set_tailBsCubeBlockDimM(tailBsCubeBlockDimM_);
+
+    return ge::GRAPH_SUCCESS;
+}
+
 ge::graphStatus HcPreTiling::CalcOpTiling() {
+    if (CalcBsSplit() == ge::GRAPH_FAILED) {
+        return ge::GRAPH_FAILED;
+    }
     uint64_t kSize = hcMult_ * d_;
     tilingData_.set_k(kSize);
     uint64_t cvLoopKSize = 1024;
     // 计算bs_轴切核
-    uint64_t mDimNum = std::min(aicCoreNum_, static_cast<uint64_t>(CeilDiv(bs_, M_L1_MAX_SIZE)));
-    uint64_t singleCoreM = RoundUp(CeilDiv(bs_, mDimNum), AscendC::BLOCK_CUBE);
+    uint64_t mDimNum = std::min(aicCoreNum_, static_cast<uint64_t>(CeilDiv(curBsSplit_, M_L1_MAX_SIZE)));
+    uint64_t singleCoreM = RoundUp(CeilDiv(curBsSplit_, mDimNum), AscendC::BLOCK_CUBE);
     uint64_t kDimNum = aicCoreNum_ / mDimNum;
     // Align splitKSize to cvLoopKSize so every core has the same number of iterations
     uint64_t splitKSize = RoundUp(CeilDiv(kSize, kDimNum), cvLoopKSize);
@@ -433,6 +513,10 @@ ge::graphStatus HcPreTiling::DoOpTiling()
         return ge::GRAPH_FAILED;
     }
 
+    if (CalcTailBsTiling() == ge::GRAPH_FAILED) {
+        return ge::GRAPH_FAILED;
+    }
+
     if (GetWorkspaceSize() == ge::GRAPH_FAILED) {
         return ge::GRAPH_FAILED;
     }
@@ -455,7 +539,7 @@ ge::graphStatus HcPreTiling::PostTiling()
     context_->SetTilingKey(0);
     context_->SetBlockDim(aicCoreNum_);
     size_t* workspaces = context_->GetWorkspaceSizes(1);
-    workspaces[0] = workspaceSize_;
+    workspaces[0] = workspaceSize_ + tilingData_.get_curBsSplit() *  d_ * 4 * 16;
     tilingData_.SaveToBuffer(context_->GetRawTilingData()->GetData(), context_->GetRawTilingData()->GetCapacity());
     context_->GetRawTilingData()->SetDataSize(tilingData_.GetDataSize());
     return ge::GRAPH_SUCCESS;

--- a/csrc/moe/hc_pre/op_host/hc_pre_tiling.h
+++ b/csrc/moe/hc_pre/op_host/hc_pre_tiling.h
@@ -102,6 +102,27 @@ TILING_DATA_FIELD_DEF(int64_t, bufferPool0Size);
 TILING_DATA_FIELD_DEF(int64_t, bufferPool1Size);
 TILING_DATA_FIELD_DEF(int64_t, mUbSize);
 
+TILING_DATA_FIELD_DEF(int64_t, bsSplitThreshold);
+TILING_DATA_FIELD_DEF(int64_t, bsLoop);
+TILING_DATA_FIELD_DEF(int64_t, tailBs);
+TILING_DATA_FIELD_DEF(int64_t, curBsSplit);
+
+// 尾批次专用参数 (tailBs != BS_SPLIT_THRESHOLD 时使用)
+TILING_DATA_FIELD_DEF(int64_t, tailBsRowOfFormerBlock);
+TILING_DATA_FIELD_DEF(int64_t, tailBsRowOfTailBlock);
+TILING_DATA_FIELD_DEF(int64_t, tailBsRowLoopOfFormerBlock);
+TILING_DATA_FIELD_DEF(int64_t, tailBsRowLoopOfTailBlock);
+TILING_DATA_FIELD_DEF(int64_t, tailBsUsedCoreNum);
+TILING_DATA_FIELD_DEF(int64_t, tailBsRowFactor);
+TILING_DATA_FIELD_DEF(int64_t, tailBsTailRowFactorOfFormerBlock);
+TILING_DATA_FIELD_DEF(int64_t, tailBsTailRowFactorOfTailBlock);
+TILING_DATA_FIELD_DEF(int64_t, tailBsML1Size);
+TILING_DATA_FIELD_DEF(int64_t, tailBsKL1Size);
+TILING_DATA_FIELD_DEF(int64_t, tailBsMultCoreSplitMSize);
+TILING_DATA_FIELD_DEF(int64_t, tailBsCubeBlockDimM);
+TILING_DATA_FIELD_DEF(int64_t, tailCvLoopsPerCore);
+TILING_DATA_FIELD_DEF(int64_t, tailTotalKSlots);
+
 END_TILING_DATA_DEF;
 
 REGISTER_TILING_DATA_CLASS(HcPre, HcPreTilingData)
@@ -129,6 +150,8 @@ public:
     ge::graphStatus CalcOpTiling();
     ge::graphStatus CalcMembaseOpTiling();
     ge::graphStatus CalcMKSplitCoreMembasePart2Tiling();
+    ge::graphStatus CalcBsSplit();
+    ge::graphStatus CalcTailBsTiling();
 
 private:
     gert::TilingContext *context_ = nullptr;
@@ -157,6 +180,22 @@ private:
     int64_t iterTimes_ = 0;
     double hcEps_ = 0.0;
     double normEps_ = 0.0;
+    int64_t bsLoop_ = 1;
+    int64_t tailBs_ = 0;
+    int64_t curBsSplit_ = 0;
+    // 尾批次专用参数
+    int64_t tailBsRowOfFormerBlock_ = 0;
+    int64_t tailBsRowOfTailBlock_ = 0;
+    int64_t tailBsRowLoopOfFormerBlock_ = 0;
+    int64_t tailBsRowLoopOfTailBlock_ = 0;
+    int64_t tailBsUsedCoreNum_ = 0;
+    int64_t tailBsRowFactor_ = 0;
+    int64_t tailBsTailRowFactorOfFormerBlock_ = 0;
+    int64_t tailBsTailRowFactorOfTailBlock_ = 0;
+    int64_t tailBsML1Size_ = 0;
+    int64_t tailBsKL1Size_ = 0;
+    int64_t tailBsMultCoreSplitMSize_ = 0;
+    int64_t tailBsCubeBlockDimM_ = 0;
     platform_ascendc::SocVersion socVersion_ = platform_ascendc::SocVersion::ASCEND910B;
 };
 

--- a/csrc/moe/hc_pre/op_kernel/hc_pre.cpp
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre.cpp
@@ -44,10 +44,10 @@ extern "C" __global__ __aicore__ void hc_pre(GM_ADDR x, GM_ADDR hc_fn, GM_ADDR h
     if (userWs == nullptr) {
         return;
     }
-    TPipe pipe;
 
     // 950PR 950DT
     #if defined(__DAV_C310__) 
+        TPipe pipe;
         if (TILING_KEY_IS(1000)) {
             GET_TILING_DATA_WITH_STRUCT(HcPreTilingData, tiling_data_in, tiling);
             const HcPreTilingData *__restrict tilingData = &tiling_data_in;
@@ -73,18 +73,27 @@ extern "C" __global__ __aicore__ void hc_pre(GM_ADDR x, GM_ADDR hc_fn, GM_ADDR h
         if (TILING_KEY_IS(0)) {
             GET_TILING_DATA_WITH_STRUCT(HcPreTilingData, tiling_data_in, tiling);
             const HcPreTilingData *__restrict tilingData = &tiling_data_in;
-            HcPre::HcPreMembaseKSplitCorePart1<DTYPE_X> op;
-            op.Init(x, hc_fn, userWs, tilingData, &pipe);
-            op.Process();
 
-            pipe.Destroy();
+            for (int64_t bsLoopIdx = 0; bsLoopIdx < tilingData->bsLoop; bsLoopIdx++) {
+                int64_t curBsOffset = bsLoopIdx * tilingData->curBsSplit;
+                int64_t curBs = (bsLoopIdx == tilingData->bsLoop - 1) ? tilingData->tailBs : tilingData->curBsSplit;
+                bool isTailBsLoop = (bsLoopIdx == tilingData->bsLoop - 1) && (tilingData->tailBs != tilingData->curBsSplit);
 
-            TPipe pipeStage2;
-            HcPre::HcPreMembaseKSplitCorePart2<DTYPE_X> op2;
-            op2.Init(x, hc_scale, hc_base, y, post, comb_frag, userWs, tilingData, &pipeStage2);
-            op2.Process();
+                TPipe pipeStage1;
+                HcPre::HcPreMembaseKSplitCorePart1<DTYPE_X> op;
+                op.Init(x, hc_fn, userWs, tilingData, &pipeStage1, curBsOffset, curBs, isTailBsLoop);
+                op.Process(curBsOffset, curBs, isTailBsLoop);
 
-            pipeStage2.Destroy();            
+                pipeStage1.Destroy();
+
+                TPipe pipeStage2;
+                HcPre::HcPreMembaseKSplitCorePart2<DTYPE_X> op2;
+                op2.Init(x, hc_scale, hc_base, y, post, comb_frag, userWs, tilingData, &pipeStage2, curBsOffset, isTailBsLoop);
+                op2.Process(curBsOffset, curBs, isTailBsLoop);
+
+                pipeStage2.Destroy();            
+                SyncAll<false>(); // cv全部同步
+            }
         }
     #endif
 }

--- a/csrc/moe/hc_pre/op_kernel/hc_pre_m_k_split_core.h
+++ b/csrc/moe/hc_pre/op_kernel/hc_pre_m_k_split_core.h
@@ -30,12 +30,17 @@ public:
     }
 
     __aicore__ inline void Init(GM_ADDR x, GM_ADDR hcFn, GM_ADDR workspace,
-                                const HcPreTilingData *tilingDataPtr, TPipe *pipePtr)
+                                const HcPreTilingData *tilingDataPtr, TPipe *pipePtr,
+                                int64_t bsOffset, int64_t curBs, bool isTailBsLoop)
     {
         pipe = pipePtr;
         tilingData = tilingDataPtr;
+        isTailBsLoop_ = isTailBsLoop;
 
-        xGm.SetGlobalBuffer((__gm__ T *)x);
+        int64_t curML1Size = isTailBsLoop ? tilingData->tailBsML1Size : tilingData->mL1Size;
+        int64_t curCubeBlockDimM = isTailBsLoop ? tilingData->tailBsCubeBlockDimM : tilingData->cubeBlockDimM;
+
+        xGm.SetGlobalBuffer((__gm__ T *)x + (bsOffset * tilingData->hcMult *tilingData->d));
         hcFnGm.SetGlobalBuffer((__gm__ float *)hcFn);
         workspaceGm.SetGlobalBuffer((__gm__ float *)workspace);
 
@@ -44,19 +49,16 @@ public:
         if ASCEND_IS_AIV {
             curCubeBlockIdx = curCubeBlockIdx / CV_RATIO;
         }
-        // uint64_t wsOffset = 0;
-        // xCastFp32WsGm.SetGlobalBuffer((__gm__ float *)workspace + wsOffset);
-        xCastFp32BufSize_ = tilingData->mL1Size * CeilAlign(tilingData->cvLoopKSize, MM_CACHE_LINE_BYTES / sizeof(float));
+        xCastFp32BufSize_ = curML1Size * CeilAlign(tilingData->cvLoopKSize, MM_CACHE_LINE_BYTES / sizeof(float));
         int64_t SingleCubeCoreXCastSize = xCastFp32BufSize_ * DOUBLE_BUFFER;
         xCastFp32WsGm.SetGlobalBuffer((__gm__ float *)workspace + curCubeBlockIdx * SingleCubeCoreXCastSize);
-        // wsOffset += DOUBLE_BUFFER * xCastFp32BufSize_;
-        uint64_t wsOffset = tilingData->cubeCoreNum * SingleCubeCoreXCastSize; //TODO need change to real value
+        uint64_t wsOffset = tilingData->cubeCoreNum * SingleCubeCoreXCastSize;
         mmOutFp32WsGm.SetGlobalBuffer((__gm__ float *)workspace + wsOffset);
         mmOuterInnerSize_ = CeilAlign(N_SIZE, MM_CACHE_LINE_BYTES / sizeof(float));
-        mmOutFp32BufSize_ = tilingData->bs * mmOuterInnerSize_;
+        mmOutFp32BufSize_ = curBs * mmOuterInnerSize_;
         wsOffset += tilingData->totalKSlots * mmOutFp32BufSize_;
         squareSumFp32WsGm.SetGlobalBuffer((__gm__ float *)workspace + wsOffset);
-        squareSumFp32BufSize_ = CeilAlign(tilingData->bs, BLOCK_CUBE) * BLOCK_CUBE;
+        squareSumFp32BufSize_ = CeilAlign(curBs, BLOCK_CUBE) * BLOCK_CUBE;
 
         if ASCEND_IS_AIC {
             cubeCompute_.Init(xCastFp32WsGm, hcFnGm, pipePtr);
@@ -68,11 +70,15 @@ public:
 
         // OutQue
         pipe->InitBuffer(mmInQue, NUM_TWO, xQueNum * sizeof(float));
-
     }
 
-    __aicore__ inline void Process() 
+    __aicore__ inline void Process(int64_t bsOffset, int64_t curBs, bool isTailBsLoop)
     {
+        isTailBsLoop_ = isTailBsLoop;
+        int64_t curML1Size = isTailBsLoop ? tilingData->tailBsML1Size : tilingData->mL1Size;
+        int64_t curKL1Size = isTailBsLoop ? tilingData->tailBsKL1Size : tilingData->kL1Size;
+        int64_t curCubeBlockDimM = isTailBsLoop ? tilingData->tailBsCubeBlockDimM : tilingData->cubeBlockDimM;
+
         if ASCEND_IS_AIC{
             // 初始设置
             CrossCoreSetFlag<SYNC_MODE2, PIPE_FIX>(SYNC_AIC_TO_AIV_FLAG);
@@ -92,9 +98,9 @@ public:
             kGmEndOffset = tilingData->k;
         }
         uint64_t curCvLoopKSize = tilingData->cvLoopKSize;
-        for (uint64_t mGmOffset = mBlkDimIdx * tilingData->mL1Size; mGmOffset < tilingData->bs;
-                mGmOffset += tilingData->cubeBlockDimM * tilingData->mL1Size) {
-            uint64_t realMSize = mGmOffset + tilingData->mL1Size > tilingData->bs ? tilingData->bs - mGmOffset : tilingData->mL1Size;
+        for (uint64_t mGmOffset = mBlkDimIdx * curML1Size; mGmOffset < curBs;
+                mGmOffset += curCubeBlockDimM * curML1Size) {
+            uint64_t realMSize = mGmOffset + curML1Size > curBs ? curBs - mGmOffset : curML1Size;
             uint64_t localIterIdx = 0;
             for (uint64_t kGmBaseOffset = kGmStartOffset; kGmBaseOffset < kGmEndOffset; kGmBaseOffset += tilingData->cvLoopKSize) {
                 uint64_t realKGmSize = kGmBaseOffset + tilingData->cvLoopKSize > kGmEndOffset ? kGmEndOffset - kGmBaseOffset : tilingData->cvLoopKSize;
@@ -102,7 +108,7 @@ public:
                 if ASCEND_IS_AIC{
                     MmParams mmParams;
                     mmParams.curML1 = realMSize;
-                    mmParams.curKL1 = tilingData->kL1Size;
+                    mmParams.curKL1 = curKL1Size;
                     mmParams.curNL1 = N_SIZE;
                     mmParams.singleCoreK = realKGmSize;
                     mmParams.xWsKSize = tilingData->cvLoopKSize;
@@ -185,17 +191,18 @@ private:
     LocalTensor<float> xCastLocal;
     LocalTensor<float> yCastLocal;
     LocalTensor<float> mmOutLocal;
-    
+
     HcCubeCompute<false> cubeCompute_;
     static constexpr uint64_t SYNC_AIV_TO_AIC_FLAG = 8;
     static constexpr uint64_t SYNC_AIC_TO_AIV_FLAG = 9;
     static constexpr uint64_t SYNC_MODE2 = NUM_TWO;
-    
+
     uint64_t cvLoopIdx_ = 0;
     uint64_t xCastFp32BufSize_;
     uint64_t mmOuterInnerSize_;
     uint64_t mmOutFp32BufSize_;
     uint64_t squareSumFp32BufSize_;
+    bool isTailBsLoop_ = false;
 };
 
 template <typename T>
@@ -207,17 +214,19 @@ public:
 
     __aicore__ inline void Init(GM_ADDR x, GM_ADDR hcScale, GM_ADDR hcBase, GM_ADDR y,
                                 GM_ADDR post, GM_ADDR combFrag, GM_ADDR workspace,
-                                const HcPreTilingData *tilingDataPtr, TPipe *pipePtr)
+                                const HcPreTilingData *tilingDataPtr, TPipe *pipePtr,
+                                int64_t bsOffset, bool isTailBsLoop)
     {
         pipe = pipePtr;
         tilingData = tilingDataPtr;
+        isTailBsLoop_ = isTailBsLoop;
 
-        xGm.SetGlobalBuffer((__gm__ T *)x);
+        xGm.SetGlobalBuffer((__gm__ T *)x + (bsOffset * tilingData->hcMult *tilingData->d));
         hcScaleGm.SetGlobalBuffer((__gm__ float *)hcScale);
         hcBaseGm.SetGlobalBuffer((__gm__ float *)hcBase);
-        yGm.SetGlobalBuffer((__gm__ T *)y);
-        postGm.SetGlobalBuffer((__gm__ float *)post);
-        combFragGm.SetGlobalBuffer((__gm__ float *)combFrag);
+        yGm.SetGlobalBuffer((__gm__ T *)y + (bsOffset * tilingData->d));
+        postGm.SetGlobalBuffer((__gm__ float *)post + (bsOffset * tilingData->hcMult));
+        combFragGm.SetGlobalBuffer((__gm__ float *)combFrag + (bsOffset * tilingData->hcMult * tilingData->hcMult));
         workspaceGm.SetGlobalBuffer((__gm__ float *)workspace);
 
         // InQue
@@ -244,7 +253,7 @@ public:
         pipe->InitBuffer(hcBaseBuf1, tilingData->hcMultAlign * sizeof(float));
         pipe->InitBuffer(hcBaseBuf2, tilingData->hcMult * tilingData->hcMultAlign * sizeof(float));
         pipe->InitBuffer(rowBrcbBuf0, RoundUp<float>(tilingData->stage2RowFactor) * BLOCK_SIZE);
-        pipe->InitBuffer(hcBrcbBuf1, RoundUp<float>(tilingData->stage2RowFactor * tilingData->hcMultAlign) * BLOCK_SIZE);
+        pipe->InitBuffer(hcBrcbBuf1, RoundUp<float>(tilingData->stage2RowFactor * tilingData->hcMultAlign * NUM_TWO) * BLOCK_SIZE);
         pipe->InitBuffer(reduceBuf, tilingData->stage2RowFactor * tilingData->hcMultAlign * sizeof(float));
         pipe->InitBuffer(mxies01ReduceBuf, tilingData->stage2RowFactor * tilingData->hcMultAlign * NUM_TWO * sizeof(float));
         pipe->InitBuffer(mxies02ReduceBuf, tilingData->stage2RowFactor * tilingData->hcMultAlign * tilingData->hcMult * sizeof(float));
@@ -270,19 +279,30 @@ public:
         SetGatherMaskPattern(maskPatternLocal);
     }
 
-    __aicore__ inline void Process() 
+    __aicore__ inline void Process(int64_t bsOffset, int64_t curBs, bool isTailBsLoop)
     {
+        isTailBsLoop_ = isTailBsLoop;
+
+        int64_t curRowOfFormerBlock = isTailBsLoop ? tilingData->tailBsRowOfFormerBlock : tilingData->rowOfFormerBlock;
+        int64_t curRowLoopOfFormerBlock = isTailBsLoop ? tilingData->tailBsRowLoopOfFormerBlock : tilingData->rowLoopOfFormerBlock;
+        int64_t curRowLoopOfTailBlock = isTailBsLoop ? tilingData->tailBsRowLoopOfTailBlock : tilingData->rowLoopOfTailBlock;
+        int64_t curSecondUsedCoreNum = isTailBsLoop ? tilingData->tailBsUsedCoreNum : tilingData->secondUsedCoreNum;
+        int64_t curStage2RowFactor = isTailBsLoop ? tilingData->tailBsRowFactor : tilingData->stage2RowFactor;
+        int64_t curTailRowFactorOfFormerBlock = isTailBsLoop ? tilingData->tailBsTailRowFactorOfFormerBlock : tilingData->tailRowFactorOfFormerBlock;
+        int64_t curTailRowFactorOfTailBlock = isTailBsLoop ? tilingData->tailBsTailRowFactorOfTailBlock : tilingData->tailRowFactorOfTailBlock;
+        int64_t curML1Size = isTailBsLoop ? tilingData->tailBsML1Size : tilingData->mL1Size;
+
         if ASCEND_IS_AIV {
             int64_t stage1UsedCoreNum = tilingData->totalKSlots;
             int64_t stage2BlockIdx = GetBlockIdx();
-            int64_t stage2UsedCoreNum = tilingData->secondUsedCoreNum;
+            int64_t stage2UsedCoreNum = curSecondUsedCoreNum;
             if (stage2BlockIdx >= stage2UsedCoreNum) {
                 return;
             }
             int64_t mmLastAxisSize = CeilAlign(tilingData->hcMix, MM_CACHE_LINE_BYTES / sizeof(float));
-            int64_t xCastFp32BufSize = tilingData->mL1Size * CeilAlign(tilingData->cvLoopKSize, MM_CACHE_LINE_BYTES / sizeof(float)) * sizeof(float);
+            int64_t xCastFp32BufSize = curML1Size * CeilAlign(tilingData->cvLoopKSize, MM_CACHE_LINE_BYTES / sizeof(float)) * sizeof(float);
             int64_t workspaceSize1 = (tilingData->cubeCoreNum * DOUBLE_BUFFER * xCastFp32BufSize) / sizeof(float);
-            int64_t workspaceSize2 = CeilAlign(stage1UsedCoreNum * tilingData->bs * mmLastAxisSize * sizeof(float), WORKSPACE_ALIGN_SIZE) / sizeof(float);
+            int64_t workspaceSize2 = CeilAlign(stage1UsedCoreNum * curBs * mmLastAxisSize * sizeof(float), WORKSPACE_ALIGN_SIZE) / sizeof(float);
             CopyIn(hcBaseGm, hcBase0Local, 1, tilingData->hcMult);
             CopyIn(hcBaseGm[tilingData->hcMult], hcBase1Local, 1, tilingData->hcMult);
             CopyIn(hcBaseGm[tilingData->hcMult * NUM_TWO], hcBase2Local, tilingData->hcMult, tilingData->hcMult);
@@ -291,23 +311,23 @@ public:
             WaitFlag<HardEvent::MTE2_V>(eventId);
 
             int64_t rowOuterLoop =
-                (stage2BlockIdx == stage2UsedCoreNum - 1) ? tilingData->rowLoopOfTailBlock : tilingData->rowLoopOfFormerBlock;
-            int64_t tailRowFactor = (stage2BlockIdx == stage2UsedCoreNum - 1) ? tilingData->tailRowFactorOfTailBlock :
-                                                                        tilingData->tailRowFactorOfFormerBlock;
-            int64_t xGmBlockBaseOffsetPart2 = stage2BlockIdx * tilingData->rowOfFormerBlock * tilingData->hcMult * tilingData->d;
+                (stage2BlockIdx == stage2UsedCoreNum - 1) ? curRowLoopOfTailBlock : curRowLoopOfFormerBlock;
+            int64_t tailRowFactor = (stage2BlockIdx == stage2UsedCoreNum - 1) ? curTailRowFactorOfTailBlock :
+                                                                        curTailRowFactorOfFormerBlock;
+            int64_t xGmBlockBaseOffsetPart2 = stage2BlockIdx * curRowOfFormerBlock * tilingData->hcMult * tilingData->d;
 
             for (int64_t rowOuterIdx = 0; rowOuterIdx < rowOuterLoop; rowOuterIdx++) { 
-                int64_t xGmBsBaseOffsetPart2 = rowOuterIdx * tilingData->stage2RowFactor * tilingData->hcMult * tilingData->d;
-                int64_t curRowFactor = (rowOuterIdx == rowOuterLoop - 1) ? tailRowFactor : tilingData->stage2RowFactor;
+                int64_t xGmBsBaseOffsetPart2 = rowOuterIdx * curStage2RowFactor * tilingData->hcMult * tilingData->d;
+                int64_t curRowFactor = (rowOuterIdx == rowOuterLoop - 1) ? tailRowFactor : curStage2RowFactor;
                 squareSumOutLocal = squareSumQue.AllocTensor<float>();
                 //todo
-                CopyIn(workspaceGm[workspaceSize1 + workspaceSize2 + stage2BlockIdx * tilingData->rowOfFormerBlock * SQUARE_SUM_SIZE + rowOuterIdx * tilingData->stage2RowFactor * SQUARE_SUM_SIZE], 
-                        squareSumOutLocal, stage1UsedCoreNum, curRowFactor * SQUARE_SUM_SIZE, CeilAlign(tilingData->bs, SQUARE_SUM_SIZE) * SQUARE_SUM_SIZE - curRowFactor * SQUARE_SUM_SIZE);
+                CopyIn(workspaceGm[workspaceSize1 + workspaceSize2 + stage2BlockIdx * curRowOfFormerBlock * SQUARE_SUM_SIZE + rowOuterIdx * curStage2RowFactor * SQUARE_SUM_SIZE], 
+                        squareSumOutLocal, stage1UsedCoreNum, curRowFactor * SQUARE_SUM_SIZE, CeilAlign(curBs, SQUARE_SUM_SIZE) * SQUARE_SUM_SIZE - curRowFactor * SQUARE_SUM_SIZE);
                 squareSumQue.EnQue(squareSumOutLocal);
                 squareSumOutLocal = squareSumQue.DeQue<float>();
                 ReduceSumARAPerf(squareReduceLocal, squareSumOutLocal, 1, stage1UsedCoreNum, curRowFactor * SQUARE_SUM_SIZE);
-                int64_t curBsIdxForAll = (stage2BlockIdx * tilingData->rowLoopOfFormerBlock + rowOuterIdx) * tilingData->stage2RowFactor;
- 	            GatherMaskByDiagonal(rsqrtLocal, squareReduceLocal, maskPatternLocal[(curBsIdxForAll % SQUARE_SUM_SIZE) * 8], curRowFactor);
+                int64_t curBsIdxForAll = (stage2BlockIdx * curRowOfFormerBlock + rowOuterIdx) * curStage2RowFactor;
+                GatherMaskByDiagonal(rsqrtLocal, squareReduceLocal, maskPatternLocal[(curBsIdxForAll % SQUARE_SUM_SIZE) * 8], curRowFactor);
                 float coeff = 1.0f / static_cast<float>(tilingData->k);
                 Muls(rsqrtLocal, rsqrtLocal, coeff, curRowFactor);
                 PipeBarrier<PIPE_V>();
@@ -319,14 +339,14 @@ public:
                 Div(rsqrtLocal, rowBrcbLocal0, rsqrtLocal, curRowFactor);
 
                 mxies01Local = mixesQue01.AllocTensor<float>();
-                
-                uint64_t mixBaseOffset = workspaceSize1 + stage2BlockIdx * tilingData->rowOfFormerBlock * CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float)) + 
-                                         rowOuterIdx * tilingData->stage2RowFactor * CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float));
+
+                uint64_t mixBaseOffset = workspaceSize1 + stage2BlockIdx * curRowOfFormerBlock * CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float)) + 
+                                         rowOuterIdx * curStage2RowFactor * CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float));
                 CopyInWithOuterFor(workspaceGm[mixBaseOffset], mxies01Local, stage1UsedCoreNum, curRowFactor, tilingData->hcMult,
-                                tilingData->bs, CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float)));
+                                curBs, CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float)));
                 CopyInWithOuterFor(workspaceGm[mixBaseOffset + tilingData->hcMult],
-                                mxies01Local[stage1UsedCoreNum * tilingData->stage2RowFactor * tilingData->hcMultAlign],
-                                stage1UsedCoreNum, curRowFactor, tilingData->hcMult, tilingData->bs,
+                                mxies01Local[stage1UsedCoreNum * curRowFactor * tilingData->hcMultAlign],
+                                stage1UsedCoreNum, curRowFactor, tilingData->hcMult, curBs,
                                 CeilAlign(tilingData->hcMix, WORKSPACE_ALIGN_SIZE / sizeof(float)));
 
                 mixesQue01.EnQue(mxies01Local);
@@ -340,7 +360,7 @@ public:
                     xLocal = xQue.template AllocTensor<T>();
                     CopyIn(xGm[xGmBlockBaseOffsetPart2 + xGmBsBaseOffsetPart2 +
                                 dLoopIdx * tilingData->dFactor],
-                            xLocal, tilingData->stage2RowFactor * tilingData->hcMult, curDFactor, tilingData->d - curDFactor);
+                            xLocal, curStage2RowFactor * tilingData->hcMult, curDFactor, tilingData->d - curDFactor);
                     xQue.template EnQue(xLocal);
                     xLocal = xQue.template DeQue<T>();
                     yLocal = yQue.template AllocTensor<T>();
@@ -350,22 +370,22 @@ public:
                     yQue.template EnQue(yLocal);
                     yLocal = yQue.template DeQue<T>();
                     CopyOut(yLocal,
-                            yGm[stage2BlockIdx * tilingData->rowOfFormerBlock * tilingData->d +
-                                rowOuterIdx * tilingData->stage2RowFactor * tilingData->d + dLoopIdx * tilingData->dFactor],
+                            yGm[stage2BlockIdx * curRowOfFormerBlock * tilingData->d +
+                                rowOuterIdx * curStage2RowFactor * tilingData->d + dLoopIdx * tilingData->dFactor],
                             curRowFactor, curDFactor, tilingData->d - curDFactor);
                     yQue.template FreeTensor(yLocal);
                 }
                 // post
                 postLocal = postQue.AllocTensor<float>();
-                ProcessPost(postLocal, mxies01ReduceLocal[tilingData->stage2RowFactor * tilingData->hcMultAlign], hcBase1Local,
+                ProcessPost(postLocal, mxies01ReduceLocal[curRowFactor * tilingData->hcMultAlign], hcBase1Local,
                             rsqrtLocal, rowBrcbLocal0, hcBrcbLocal1, hcScaleGm.GetValue(1), curRowFactor,
                             tilingData->hcMult);
                 mixesQue01.template FreeTensor(mxies01Local);
                 postQue.EnQue(postLocal);
                 postLocal = postQue.DeQue<float>();
                 CopyOut(postLocal,
-                        postGm[stage2BlockIdx * tilingData->rowOfFormerBlock * tilingData->hcMult +
-                                rowOuterIdx * tilingData->stage2RowFactor * tilingData->hcMult],
+                        postGm[stage2BlockIdx * curRowOfFormerBlock * tilingData->hcMult +
+                                rowOuterIdx * curStage2RowFactor * tilingData->hcMult],
                         curRowFactor, tilingData->hcMult);
                 postQue.FreeTensor(postLocal);
 
@@ -373,7 +393,7 @@ public:
                 mixes2Local = mixesQue2.AllocTensor<float>();
                 for (int64_t i = 0; i < stage1UsedCoreNum; ++i) {
                     for (int64_t j = 0; j < curRowFactor; ++j) {
-                        CopyIn(workspaceGm[workspaceSize1 + i * tilingData->bs * mmLastAxisSize + j * mmLastAxisSize + stage2BlockIdx * tilingData->rowOfFormerBlock * mmLastAxisSize + rowOuterIdx * tilingData->stage2RowFactor * mmLastAxisSize + tilingData->hcMult * NUM_TWO],
+                        CopyIn(workspaceGm[workspaceSize1 + i * curBs * mmLastAxisSize + j * mmLastAxisSize + stage2BlockIdx * curRowOfFormerBlock * mmLastAxisSize + rowOuterIdx * curStage2RowFactor * mmLastAxisSize + tilingData->hcMult * NUM_TWO],
                                         mixes2Local[(i * curRowFactor + j) * tilingData->hcMult * tilingData->hcMultAlign], tilingData->hcMult, tilingData->hcMult);
                     }
                 }
@@ -414,8 +434,8 @@ public:
                 combFragQue.EnQue(combFragLocal);
                 combFragLocal = combFragQue.DeQue<float>();
                 CopyOut(combFragLocal,
-                        combFragGm[stage2BlockIdx * tilingData->rowOfFormerBlock * tilingData->hcMult * tilingData->hcMult +
-                                    rowOuterIdx * tilingData->stage2RowFactor * tilingData->hcMult * tilingData->hcMult],
+                        combFragGm[stage2BlockIdx * curRowOfFormerBlock * tilingData->hcMult * tilingData->hcMult +
+                                    rowOuterIdx * curStage2RowFactor * tilingData->hcMult * tilingData->hcMult],
                         curRowFactor * tilingData->hcMult, tilingData->hcMult);
                 combFragQue.FreeTensor(combFragLocal);
             }
@@ -435,6 +455,7 @@ private:
     GlobalTensor<float> postGm;
     GlobalTensor<float> combFragGm;
 
+    bool isTailBsLoop_ = false;
     TQue<QuePosition::VECIN, 1> mixesQue01;
     TQue<QuePosition::VECIN, 1> mixesQue2;
     TQue<QuePosition::VECIN, 1> xQue;

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -828,7 +828,7 @@ class DeepseekV2DecoderLayer(nn.Module):
 
     def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor,
                hc_scale: torch.Tensor, hc_base: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_pre(x, hc_fn, hc_scale, hc_base,
+        y = torch.ops._C_ascend.npu_hc_pre_v2(x, hc_fn, hc_scale, hc_base,
                                            self.hc_mult,
                                            self.hc_sinkhorn_iters,
                                            self.norm_eps, self.hc_eps)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

Fix the precision of the hc_pre_v2 operator
- The BS splitting policy is added to avoid insufficient workspace.

GPQA score with deepseek-v4-flash
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| GPQA_diamond | b1ed2c | accuracy | gen | 90.40 |

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
