### PR TITLE
optimize shared expert overlap timing

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -65,6 +65,7 @@ class FusedMoEResult:
 @dataclass
 class FusedMoEEvents:
     before_routed_experts: torch.npu.Event
+    after_routed_experts: torch.npu.Event | None = field(default=None)
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
@@ -738,7 +739,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
-                maybe_wait_event(fused_moe_evts.before_dispatch)
+                maybe_wait_event(fused_moe_evts.after_routed_experts)
                 hidden_states = torch_npu.npu_quant_matmul(
                     quantized_x,
                     self._shared_experts.gate_up_proj.weight,
@@ -815,8 +816,10 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             hidden_states_fp32 = hidden_states.float()
             before_routed_experts = torch.npu.current_stream().record_event()
             router_logits = F.linear(hidden_states_fp32, self.gate.weight_fp32)
+            after_routed_experts = torch.npu.current_stream().record_event()
         else:
             before_routed_experts = torch.npu.current_stream().record_event()
+            after_routed_experts = None
 
         fused_moe_results = AscendFusedMoE.forward_impl(
             self,
@@ -837,6 +840,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
             shared_out = self._forward_shared_experts(
                 hidden_states,
                 FusedMoEEvents(
+                    after_routed_experts=after_routed_experts,
                     before_routed_experts=before_routed_experts,
                     before_dispatch=fused_moe_results.before_dispatch_evt,
                     before_gmm2=fused_moe_results.before_gmm2_evt,


### PR DESCRIPTION
### What this PR does / why we need it?

优化共享专家多流的等待时机，让共享流（Stream 1）的 matmul gate_up 能更早起步，扩大与主流 routed 的 overlap 窗口。

**改动前**：共享流的 `matmul gate_up` 等待 `fused_moe_evts.before_dispatch`，意味着要等主流 `cast → matmul(gate) → moegating_Topk → quant` 全部完成（即将进入 dispatch HCCL 段）才能开始。

**改动后**：新增 `after_routed_experts` event，在主流完成 `F.linear(hidden_states_fp32, gate.weight_fp32)`（fp32 gate matmul）后立刻 record。共享流改为 wait 这个更早的 event，提前进入计算。

### Modifications

`vllm_ascend/ops/fused_moe/fused_moe.py` 一个文件，+5 -1 行：

- `FusedMoEEvents` 增加 `after_routed_experts: torch.npu.Event | None` 字段
- `AscendSharedFusedMoE.forward_impl` 在 `multistream_overlap_shared_expert` 路径下，gate matmul 完成后 record `after_routed_experts`
- `_forward_shared_experts` W8A8 路径中，把 `maybe_wait_event(before_dispatch)` 改为 `maybe_wait_event(after_routed_experts)`

### Effect

- 共享流起步时机提前到 fp32 gate 之后（不再等到 quant 完成）
- 主流 routed 路径上"prepare quant → dispatch"段时间被共享流的 matmul gate_up 更充分掩盖
- 仅影响 `multistream_overlap_shared_expert=True` 时的 W8A8 路径，对其他配置无影响

### Testing

- [ ] A3 单机 TP8 DP2 EP=16 decode 回归（含 / 不含 FUSED_MC2 env=1）
- [ ] A2 单机 TP8 DP1 EP=8（ALLGATHER 路径不受影响，确认无回退）
- [ ] msprof 验证共享流 IDLE 段缩短
- [ ] 精度 sanity（C-Eval / MMLU 子集）