### PR TITLE
Avoid redundant CompressorDecode calls

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1523,8 +1523,6 @@ class AscendDSAImpl(DSAAttentionImpl):
         if self.compress_ratio > 1:
             compress_cos = compress_common_attn_metadata.decode.compress_cos[layer_name]
             compress_sin = compress_common_attn_metadata.decode.compress_sin[layer_name]
-            has_compressor_decode_tokens = (
-                compressor_attn_metadata.decode.slot_mapping.numel() > 0)
             compress_topk_idxs = None
             if self.compress_ratio == 4:
                 compress_topk_idxs = self.indexer_select_qli(
@@ -1543,33 +1541,34 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             coff = 2 if self.compressor_overlap else 1
 
-            if has_compressor_decode_tokens:
-                # compressor
-                compressed_kv = torch.ops._C_ascend.compressor(
-                    hidden_states,
-                    self.compressor_wkv.weight,
-                    self.compressor_wgate.weight,
-                    state_cache.squeeze(-2),
-                    self.compressor_ape,
-                    self.compressor_norm.weight,
-                    compress_sin.view(-1, compress_sin.shape[-1]),
-                    compress_cos.view(-1, compress_cos.shape[-1]),
-                    state_block_table=compressor_kv_state_metadata.decode.block_table,
-                    cu_seqlens=actual_seq_lengths_query,
-                    seqused=None,
-                    start_pos=compress_common_attn_metadata.decode.start_pos,
-                    rope_head_dim=self.rope_head_dim,
-                    cmp_ratio=self.compress_ratio,
-                    coff=coff,
-                    norm_eps=self.compressor_norm_eps,
-                    rotary_mode=2,
-                    cache_mode=1)
-                # kv_compress_epilog
-                if compressed_kv.numel() > 0:
-                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                        compress_kv_cache,
-                        compressor_attn_metadata.decode.slot_mapping,
-                        compressed_kv)
+            # The compressor op updates state_cache on every decode token.
+            # Non-boundary steps may return an empty compressed_kv, but skipping
+            # the op loses the accumulated state needed by the next boundary.
+            compressed_kv = torch.ops._C_ascend.compressor(
+                hidden_states,
+                self.compressor_wkv.weight,
+                self.compressor_wgate.weight,
+                state_cache.squeeze(-2),
+                self.compressor_ape,
+                self.compressor_norm.weight,
+                compress_sin.view(-1, compress_sin.shape[-1]),
+                compress_cos.view(-1, compress_cos.shape[-1]),
+                state_block_table=compressor_kv_state_metadata.decode.block_table,
+                cu_seqlens=actual_seq_lengths_query,
+                seqused=None,
+                start_pos=compress_common_attn_metadata.decode.start_pos,
+                rope_head_dim=self.rope_head_dim,
+                cmp_ratio=self.compress_ratio,
+                coff=coff,
+                norm_eps=self.compressor_norm_eps,
+                rotary_mode=2,
+                cache_mode=1)
+            # kv_compress_epilog
+            if compressed_kv.numel() > 0:
+                torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                    compress_kv_cache,
+                    compressor_attn_metadata.decode.slot_mapping,
+                    compressed_kv)
         if self.compress_ratio <= 1:
             attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
@@ -1686,32 +1685,30 @@ class AscendDSAImpl(DSAAttentionImpl):
             start_pos = indexer_kv_scale_metadata.decode.start_pos
             slot_mapping = indexer_kv_scale_metadata.decode.slot_mapping
 
-        kv = None
-        if slot_mapping.numel() > 0:
-            kv = torch.ops._C_ascend.compressor(
-                x,
-                self.indexcom_wkv.weight,
-                self.indexcom_wgate.weight,
-                indexer_state_cache.squeeze(-2),
-                self.indexcom_ape,
-                self.indexcom_norm.weight,
-                compressed_sin.view(-1, compressed_sin.shape[-1]),
-                compressed_cos.view(-1, compressed_cos.shape[-1]),
-                state_block_table=kv_block_table,
-                cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
-                start_pos=start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
-                coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
-                cache_mode=1)
+        kv = torch.ops._C_ascend.compressor(
+            x,
+            self.indexcom_wkv.weight,
+            self.indexcom_wgate.weight,
+            indexer_state_cache.squeeze(-2),
+            self.indexcom_ape,
+            self.indexcom_norm.weight,
+            compressed_sin.view(-1, compressed_sin.shape[-1]),
+            compressed_cos.view(-1, compressed_cos.shape[-1]),
+            state_block_table=kv_block_table,
+            cu_seqlens=actual_seq_lengths_query,
+            seqused=None,
+            start_pos=start_pos,
+            rope_head_dim=self.rope_head_dim,
+            cmp_ratio=self.compress_ratio,
+            coff=coff,
+            norm_eps=self.compressor_norm_eps,
+            rotary_mode=2,
+            cache_mode=1)
 
-            if kv.numel() == 0:
-                kv = None
-            elif self.indexer.compressor.rotate:
-                kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
+        if kv.numel() == 0:
+            kv = None
+        elif self.indexer.compressor.rotate:
+            kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
 
         weights = self.weights_proj(x) * (self.indexer_softmax_scale *
                                           self.indexer_heads ** -0.5)

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1523,6 +1523,8 @@ class AscendDSAImpl(DSAAttentionImpl):
         if self.compress_ratio > 1:
             compress_cos = compress_common_attn_metadata.decode.compress_cos[layer_name]
             compress_sin = compress_common_attn_metadata.decode.compress_sin[layer_name]
+            has_compressor_decode_tokens = (
+                compressor_attn_metadata.decode.slot_mapping.numel() > 0)
             compress_topk_idxs = None
             if self.compress_ratio == 4:
                 compress_topk_idxs = self.indexer_select_qli(
@@ -1541,31 +1543,33 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             coff = 2 if self.compressor_overlap else 1
 
-            # compressor
-            compressed_kv = torch.ops._C_ascend.compressor(
-                hidden_states,
-                self.compressor_wkv.weight,
-                self.compressor_wgate.weight,
-                state_cache.squeeze(-2),
-                self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
-                state_block_table=compressor_kv_state_metadata.decode.block_table,
-                cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
-                start_pos=compress_common_attn_metadata.decode.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
-                coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
-                cache_mode=1)
-            # kv_compress_epilog
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(
-                compress_kv_cache,
-                compressor_attn_metadata.decode.slot_mapping,
-                compressed_kv)
+            if has_compressor_decode_tokens:
+                # compressor
+                compressed_kv = torch.ops._C_ascend.compressor(
+                    hidden_states,
+                    self.compressor_wkv.weight,
+                    self.compressor_wgate.weight,
+                    state_cache.squeeze(-2),
+                    self.compressor_ape,
+                    self.compressor_norm.weight,
+                    compress_sin.view(-1, compress_sin.shape[-1]),
+                    compress_cos.view(-1, compress_cos.shape[-1]),
+                    state_block_table=compressor_kv_state_metadata.decode.block_table,
+                    cu_seqlens=actual_seq_lengths_query,
+                    seqused=None,
+                    start_pos=compress_common_attn_metadata.decode.start_pos,
+                    rope_head_dim=self.rope_head_dim,
+                    cmp_ratio=self.compress_ratio,
+                    coff=coff,
+                    norm_eps=self.compressor_norm_eps,
+                    rotary_mode=2,
+                    cache_mode=1)
+                # kv_compress_epilog
+                if compressed_kv.numel() > 0:
+                    torch.ops._C_ascend.npu_scatter_nd_update_v2(
+                        compress_kv_cache,
+                        compressor_attn_metadata.decode.slot_mapping,
+                        compressed_kv)
         if self.compress_ratio <= 1:
             attn_output = torch.ops._C_ascend.npu_sparse_attn_sharedkv(
                 q,
@@ -1675,35 +1679,39 @@ class AscendDSAImpl(DSAAttentionImpl):
             assert indexer_kv_scale_metadata.prefill is not None
             kv_block_table = indexer_kv_state_metadata.prefill.block_table
             start_pos = indexer_kv_scale_metadata.prefill.start_pos
+            slot_mapping = indexer_kv_scale_metadata.prefill.slot_mapping
         else:
             assert indexer_kv_scale_metadata.decode is not None
             kv_block_table = indexer_kv_state_metadata.decode.block_table
             start_pos = indexer_kv_scale_metadata.decode.start_pos
+            slot_mapping = indexer_kv_scale_metadata.decode.slot_mapping
 
-        kv = torch.ops._C_ascend.compressor(
-            x,
-            self.indexcom_wkv.weight,
-            self.indexcom_wgate.weight,
-            indexer_state_cache.squeeze(-2),
-            self.indexcom_ape,
-            self.indexcom_norm.weight,
-            compressed_sin.view(-1, compressed_sin.shape[-1]),
-            compressed_cos.view(-1, compressed_cos.shape[-1]),
-            state_block_table=kv_block_table,
-            cu_seqlens=actual_seq_lengths_query,
-            seqused=None,
-            start_pos=start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
-            coff=coff,
-            norm_eps=self.compressor_norm_eps,
-            rotary_mode=2,
-            cache_mode=1)
+        kv = None
+        if slot_mapping.numel() > 0:
+            kv = torch.ops._C_ascend.compressor(
+                x,
+                self.indexcom_wkv.weight,
+                self.indexcom_wgate.weight,
+                indexer_state_cache.squeeze(-2),
+                self.indexcom_ape,
+                self.indexcom_norm.weight,
+                compressed_sin.view(-1, compressed_sin.shape[-1]),
+                compressed_cos.view(-1, compressed_cos.shape[-1]),
+                state_block_table=kv_block_table,
+                cu_seqlens=actual_seq_lengths_query,
+                seqused=None,
+                start_pos=start_pos,
+                rope_head_dim=self.rope_head_dim,
+                cmp_ratio=self.compress_ratio,
+                coff=coff,
+                norm_eps=self.compressor_norm_eps,
+                rotary_mode=2,
+                cache_mode=1)
 
-        if kv.numel() == 0:
-            kv = None
-        elif self.indexer.compressor.rotate:
-            kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
+            if kv.numel() == 0:
+                kv = None
+            elif self.indexer.compressor.rotate:
+                kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
 
         weights = self.weights_proj(x) * (self.indexer_softmax_scale *
                                           self.indexer_heads ** -0.5)

--- a/vllm_ascend/core/compressor_schedule.py
+++ b/vllm_ascend/core/compressor_schedule.py
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+
+from __future__ import annotations
+
+from functools import cached_property
+
+from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
+from vllm.v1.request import Request
+
+
+def _unwrap_kv_cache_spec(kv_cache_group):
+    kv_cache_spec = kv_cache_group.kv_cache_spec
+    if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+        kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+    return kv_cache_spec
+
+
+class CompressorScheduleGroup:
+    """Track one homogeneous compressor state group for a scheduler step.
+
+    The model runner uses a different compressed KV-cache write path when a
+    decode request reaches a compressed boundary. Mixing boundary and
+    non-boundary decode requests in one batch makes the graph/compressor path
+    ambiguous. This helper lets the scheduler accept only requests with the same
+    per-KV-cache compressed-token delta in the current scheduling step.
+    """
+
+    def __init__(self, kv_cache_config: KVCacheConfig) -> None:
+        self.kv_cache_config = kv_cache_config
+        self._decode_key: tuple[int, ...] | None = None
+        self._has_non_decode = False
+
+    @cached_property
+    def compress_ratios(self) -> tuple[int, ...]:
+        ratios: list[int] = []
+        for kv_cache_group in self.kv_cache_config.kv_cache_groups:
+            kv_cache_spec = _unwrap_kv_cache_spec(kv_cache_group)
+            ratio = int(getattr(kv_cache_spec, "compress_ratio", 1))
+            if ratio > 1:
+                ratios.append(ratio)
+        return tuple(ratios)
+
+    @property
+    def enabled(self) -> bool:
+        return len(self.compress_ratios) > 0
+
+    def get_key(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_computed_tokens: int | None = None,
+    ) -> tuple[int, ...] | None:
+        if not self.enabled:
+            return None
+
+        computed_tokens = (
+            request.num_computed_tokens
+            if num_computed_tokens is None
+            else num_computed_tokens
+        )
+        if computed_tokens < request.num_prompt_tokens:
+            return None
+
+        return tuple(
+            (computed_tokens + num_new_tokens) // ratio
+            - computed_tokens // ratio
+            for ratio in self.compress_ratios
+        )
+
+    def can_accept(self, key: tuple[int, ...] | None) -> bool:
+        if not self.enabled:
+            return True
+
+        if key is None:
+            return self._decode_key is None
+
+        if self._has_non_decode:
+            return False
+
+        return self._decode_key is None or self._decode_key == key
+
+    def accept(self, key: tuple[int, ...] | None) -> None:
+        if not self.enabled:
+            return
+
+        if key is None:
+            self._has_non_decode = True
+        elif self._decode_key is None:
+            self._decode_key = key
+

--- a/vllm_ascend/core/compressor_schedule.py
+++ b/vllm_ascend/core/compressor_schedule.py
@@ -28,10 +28,14 @@ class CompressorScheduleGroup:
     per-KV-cache compressed-token delta in the current scheduling step.
     """
 
-    def __init__(self, kv_cache_config: KVCacheConfig) -> None:
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        target_decode_key: tuple[int, ...] | None = None,
+    ) -> None:
         self.kv_cache_config = kv_cache_config
+        self._target_decode_key = target_decode_key
         self._decode_key: tuple[int, ...] | None = None
-        self._has_non_decode = False
 
     @cached_property
     def compress_ratios(self) -> tuple[int, ...]:
@@ -46,6 +50,10 @@ class CompressorScheduleGroup:
     @property
     def enabled(self) -> bool:
         return len(self.compress_ratios) > 0
+
+    @property
+    def decode_key(self) -> tuple[int, ...] | None:
+        return self._decode_key
 
     def get_key(
         self,
@@ -75,9 +83,10 @@ class CompressorScheduleGroup:
             return True
 
         if key is None:
-            return self._decode_key is None
+            # Prefill/chunked-prefill is not a CompressorDecode request.
+            return True
 
-        if self._has_non_decode:
+        if self._target_decode_key is not None and key != self._target_decode_key:
             return False
 
         return self._decode_key is None or self._decode_key == key
@@ -86,8 +95,5 @@ class CompressorScheduleGroup:
         if not self.enabled:
             return
 
-        if key is None:
-            self._has_non_decode = True
-        elif self._decode_key is None:
+        if key is not None and self._decode_key is None:
             self._decode_key = key
-

--- a/vllm_ascend/core/scheduler_dynamic_batch.py
+++ b/vllm_ascend/core/scheduler_dynamic_batch.py
@@ -23,6 +23,7 @@ from vllm.distributed.kv_events import KVEventBatch
 from vllm.logger import logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -30,6 +31,8 @@ from vllm.v1.engine import EngineCoreEventType
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
+
+from vllm_ascend.core.compressor_schedule import CompressorScheduleGroup
 
 
 class BudgetRefiner:
@@ -185,6 +188,7 @@ class SchedulerDynamicBatch(Scheduler):
 
         # For logging.
         scheduled_timestamp = time.monotonic()
+        compressor_group = CompressorScheduleGroup(self.kv_cache_config)
 
         # First, schedule the RUNNING requests.
         req_index = 0
@@ -226,6 +230,11 @@ class SchedulerDynamicBatch(Scheduler):
                 # in v1 scheduler, we strictly follow the FCFS scheduling policy.
                 req_index += 1
                 break
+
+            compressor_key = compressor_group.get_key(request, num_new_tokens)
+            if not compressor_group.can_accept(compressor_key):
+                req_index += 1
+                continue
 
             while True:
                 new_blocks = self.kv_cache_manager.allocate_slots(
@@ -272,6 +281,7 @@ class SchedulerDynamicBatch(Scheduler):
             num_scheduled_tokens[request.request_id] = num_new_tokens
             token_budget -= num_new_tokens
             req_index += 1
+            compressor_group.accept(compressor_key)
 
             # Speculative decode related.
             if request.spec_token_ids:
@@ -418,6 +428,14 @@ class SchedulerDynamicBatch(Scheduler):
                             # The request cannot be scheduled.
                             break
 
+                compressor_key = compressor_group.get_key(
+                    request,
+                    num_new_tokens,
+                    num_computed_tokens,
+                )
+                if not compressor_group.can_accept(compressor_key):
+                    break
+
                 # Handles an edge case when P/D Disaggregation
                 # is used with Spec Decoding where an
                 # extra block gets allocated which
@@ -486,6 +504,7 @@ class SchedulerDynamicBatch(Scheduler):
                 req_to_new_blocks[request.request_id] = self.kv_cache_manager.get_blocks(request.request_id)
                 num_scheduled_tokens[request.request_id] = num_new_tokens
                 token_budget -= num_new_tokens
+                compressor_group.accept(compressor_key)
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 # Count the number of prefix cached tokens.
@@ -574,3 +593,11 @@ class SchedulerDynamicBatch(Scheduler):
 
         self._update_after_schedule(scheduler_output)
         return scheduler_output
+
+
+class CompressorScheduler(SchedulerDynamicBatch):
+    """SchedulerDynamicBatch with compressor-state homogeneous batching."""
+
+
+class AsyncCompressorScheduler(AsyncScheduler, CompressorScheduler):
+    pass

--- a/vllm_ascend/core/scheduler_dynamic_batch.py
+++ b/vllm_ascend/core/scheduler_dynamic_batch.py
@@ -16,6 +16,7 @@
 #
 import os
 import time
+from collections import Counter
 
 import pandas as pd
 from vllm.config import VllmConfig
@@ -149,6 +150,76 @@ class SchedulerDynamicBatch(Scheduler):
             default_budget=self.scheduler_config.max_num_batched_tokens,
             slo_limit=self.scheduler_config.SLO_limits_for_dynamic_batch,
         )
+        self._last_compressor_decode_key: tuple[int, ...] | None = None
+        self._compressor_decode_key_repeats = 0
+        self._compressor_decode_key_max_repeats = max(
+            1,
+            int(os.getenv("VLLM_ASCEND_COMPRESSOR_DECODE_KEY_MAX_REPEATS", "3")),
+        )
+
+    def _choose_compressor_decode_key(
+        self,
+        requests: list[Request],
+        token_budget: int,
+    ) -> tuple[int, ...] | None:
+        compressor_group = CompressorScheduleGroup(self.kv_cache_config)
+        if not compressor_group.enabled or token_budget <= 0:
+            return None
+
+        key_counts: Counter[tuple[int, ...]] = Counter()
+        for request in requests:
+            if request.num_computed_tokens < request.num_prompt_tokens:
+                continue
+
+            num_new_tokens = (
+                request.num_tokens_with_spec
+                + request.num_output_placeholders
+                - request.num_computed_tokens
+            )
+            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
+                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+            num_new_tokens = min(
+                num_new_tokens,
+                token_budget,
+                self.max_model_len - 1 - request.num_computed_tokens,
+            )
+            if num_new_tokens <= 0:
+                continue
+
+            key = compressor_group.get_key(request, num_new_tokens)
+            if key is not None:
+                key_counts[key] += 1
+
+        if not key_counts:
+            self._last_compressor_decode_key = None
+            self._compressor_decode_key_repeats = 0
+            return None
+
+        max_count = max(key_counts.values())
+        candidates = [key for key, count in key_counts.items() if count == max_count]
+        if len(candidates) == 1:
+            target_key = candidates[0]
+        elif self._last_compressor_decode_key in candidates:
+            last_index = candidates.index(self._last_compressor_decode_key)
+            target_key = candidates[(last_index + 1) % len(candidates)]
+        else:
+            target_key = candidates[0]
+
+        if (
+            target_key == self._last_compressor_decode_key
+            and self._compressor_decode_key_repeats >= self._compressor_decode_key_max_repeats
+            and len(key_counts) > 1
+        ):
+            # Avoid repeatedly advancing one compressor phase while another
+            # phase waits at the decode boundary.
+            alternatives = [
+                key for key, _ in key_counts.most_common()
+                if key != target_key
+            ]
+            if alternatives:
+                return alternatives[0]
+
+        return target_key
 
     def schedule(self) -> SchedulerOutput:
         # NOTE: This scheduling algorithm is developed based on the "super.schedule()"
@@ -188,7 +259,14 @@ class SchedulerDynamicBatch(Scheduler):
 
         # For logging.
         scheduled_timestamp = time.monotonic()
-        compressor_group = CompressorScheduleGroup(self.kv_cache_config)
+        target_compressor_decode_key = self._choose_compressor_decode_key(
+            self.running,
+            token_budget,
+        )
+        compressor_group = CompressorScheduleGroup(
+            self.kv_cache_config,
+            target_decode_key=target_compressor_decode_key,
+        )
 
         # First, schedule the RUNNING requests.
         req_index = 0
@@ -592,6 +670,12 @@ class SchedulerDynamicBatch(Scheduler):
             self.kv_event_publisher.publish(batch)
 
         self._update_after_schedule(scheduler_output)
+        if compressor_group.enabled and compressor_group.decode_key is not None:
+            if compressor_group.decode_key == self._last_compressor_decode_key:
+                self._compressor_decode_key_repeats += 1
+            else:
+                self._last_compressor_decode_key = compressor_group.decode_key
+                self._compressor_decode_key_repeats = 1
         return scheduler_output
 
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -439,8 +439,31 @@ class NPUPlatform(Platform):
             recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
             vllm_config.scheduler_config = recompute_scheduler_config
 
+        model_uses_compressor = bool(
+            model_config is not None
+            and hasattr(getattr(model_config, "hf_config", None), "compress_ratios")
+        )
+        if model_uses_compressor and not ascend_config.recompute_scheduler_enable:
+            scheduler_cls = (
+                "vllm_ascend.core.scheduler_dynamic_batch.AsyncCompressorScheduler"
+                if vllm_config.scheduler_config.async_scheduling
+                else "vllm_ascend.core.scheduler_dynamic_batch.CompressorScheduler"
+            )
+            vllm_config.scheduler_config.scheduler_cls = scheduler_cls
+            vllm_config.scheduler_config.SLO_limits_for_dynamic_batch = (
+                ascend_config.SLO_limits_for_dynamic_batch
+            )
+            logger.info(
+                "Compressor-aware scheduler enabled for homogeneous "
+                "compressed decode batches: %s",
+                scheduler_cls,
+            )
+
         # Extend original scheduler_config to use SchedulerDynamicBatch.
-        if ascend_config.SLO_limits_for_dynamic_batch != -1:
+        if (
+            ascend_config.SLO_limits_for_dynamic_batch != -1
+            and not model_uses_compressor
+        ):
             vllm_config.scheduler_config.scheduler_cls = (
                 "vllm_ascend.core.scheduler_dynamic_batch.SchedulerDynamicBatch"
             )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1235,6 +1235,26 @@ class NPUModelRunner(GPUModelRunner):
                         scheduler_output.num_common_prefix_blocks,
                     )
 
+                def _has_new_compressed_tokens() -> bool:
+                    if not self.use_compress or num_scheduled_tokens_compressed_list is None:
+                        return False
+                    for compressed_counts, kv_cache_group in zip(
+                        num_scheduled_tokens_compressed_list,
+                        self.kv_cache_config.kv_cache_groups,
+                    ):
+                        kv_cache_spec = kv_cache_group.kv_cache_spec
+                        if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                            kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+                        if getattr(kv_cache_spec, "compress_ratio", 1) > 1 and np.any(compressed_counts > 0):
+                            return True
+                    return False
+
+                force_eager_for_compressor_decode = (
+                    self.use_compress
+                    and not self.with_prefill
+                    and _has_new_compressed_tokens()
+                )
+
                 (
                     cudagraph_mode,
                     batch_desc,
@@ -1247,7 +1267,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     max_num_scheduled_tokens=max_num_scheduled_tokens,
                     use_cascade_attn=cascade_attn_prefix_lens is not None,
-                    force_eager=self.model_config.enforce_eager,
+                    force_eager=self.model_config.enforce_eager or force_eager_for_compressor_decode,
                     num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
                 )
 
@@ -2476,7 +2496,9 @@ class NPUModelRunner(GPUModelRunner):
             pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
             # check how to build dummy
             if self.use_compress:
-                self.positions.np.fill(127)
+                # Capture the common non-boundary compressed-decode graph
+                # without the compressor op. Boundary steps force eager.
+                self.positions.np.fill(0)
                 self.positions.copy_to_gpu()
             attn_metadata, _ = self._build_attention_metadata(
                 num_tokens=num_tokens_unpadded,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -238,6 +238,38 @@ class ExecuteModelState(NamedTuple):
     batch_desc: BatchDescriptor
 
 
+@dataclass(frozen=True)
+class AscendBatchDescriptor:
+    """Ascend graph key with optional Compressor decode state.
+
+    vLLM's BatchDescriptor only differentiates shape/LoRA state. Compressor
+    decode changes the captured operator path for the same shape, so the graph
+    key needs one more static dimension when a compressed boundary is present.
+    """
+
+    num_tokens: int
+    num_reqs: int | None = None
+    uniform: bool = False
+    has_lora: bool = False
+    num_active_loras: int = 0
+    compressor_decode_key: tuple[int, ...] | None = None
+
+    @classmethod
+    def from_batch_descriptor(
+        cls,
+        batch_desc: BatchDescriptor,
+        compressor_decode_key: tuple[int, ...],
+    ) -> "AscendBatchDescriptor":
+        return cls(
+            num_tokens=batch_desc.num_tokens,
+            num_reqs=batch_desc.num_reqs,
+            uniform=batch_desc.uniform,
+            has_lora=batch_desc.has_lora,
+            num_active_loras=batch_desc.num_active_loras,
+            compressor_decode_key=compressor_decode_key,
+        )
+
+
 class NPUModelRunner(GPUModelRunner):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         # TODO(qcs): These manual pad and unpad for GPUModelRunner are
@@ -461,6 +493,88 @@ class NPUModelRunner(GPUModelRunner):
     @property
     def use_cp(self) -> bool:
         return self.pcp_size * self.dcp_size > 1
+
+    def _iter_compress_ratios(self) -> tuple[int, ...]:
+        if not self.use_compress or not hasattr(self, "kv_cache_config"):
+            return ()
+        ratios: list[int] = []
+        for kv_cache_group in self.kv_cache_config.kv_cache_groups:
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+            ratio = int(getattr(kv_cache_spec, "compress_ratio", 1))
+            if ratio > 1:
+                ratios.append(ratio)
+        return tuple(ratios)
+
+    def _compressor_decode_graph_keys(self) -> set[tuple[int, ...]]:
+        ratios = self._iter_compress_ratios()
+        if not ratios:
+            return set()
+
+        period = 1
+        for ratio in ratios:
+            period = math.lcm(period, ratio)
+
+        graph_keys: set[tuple[int, ...]] = set()
+        for position in range(period):
+            key = tuple(1 if (position + 1) % ratio == 0 else 0 for ratio in ratios)
+            if any(key):
+                graph_keys.add(key)
+        return graph_keys
+
+    def _dummy_compressor_decode_position(
+        self,
+        compressor_decode_key: tuple[int, ...] | None,
+    ) -> int:
+        if compressor_decode_key is None:
+            return 0
+
+        ratios = self._iter_compress_ratios()
+        if len(ratios) != len(compressor_decode_key):
+            return 0
+
+        period = 1
+        for ratio in ratios:
+            period = math.lcm(period, ratio)
+
+        for position in range(period):
+            key = tuple(1 if (position + 1) % ratio == 0 else 0 for ratio in ratios)
+            if key == compressor_decode_key:
+                return position
+        return 0
+
+    def _get_compressor_decode_key(
+        self,
+        num_scheduled_tokens_compressed_list: list[np.ndarray] | None,
+        num_reqs: int,
+    ) -> tuple[tuple[int, ...] | None, bool]:
+        if not self.use_compress or num_scheduled_tokens_compressed_list is None:
+            return None, True
+
+        key: list[int] = []
+        homogeneous = True
+        for compressed_counts, kv_cache_group in zip(
+            num_scheduled_tokens_compressed_list,
+            self.kv_cache_config.kv_cache_groups,
+        ):
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+            if int(getattr(kv_cache_spec, "compress_ratio", 1)) <= 1:
+                continue
+
+            counts = compressed_counts[:num_reqs]
+            if counts.size == 0:
+                key.append(0)
+                continue
+
+            first_count = int(counts[0])
+            if not np.all(counts == first_count):
+                homogeneous = False
+            key.append(first_count)
+
+        return (tuple(key) if key else None), homogeneous
 
     def _init_device_properties(self) -> None:
         self.num_sms = None
@@ -1235,24 +1349,32 @@ class NPUModelRunner(GPUModelRunner):
                         scheduler_output.num_common_prefix_blocks,
                     )
 
-                def _has_new_compressed_tokens() -> bool:
-                    if not self.use_compress or num_scheduled_tokens_compressed_list is None:
-                        return False
-                    for compressed_counts, kv_cache_group in zip(
-                        num_scheduled_tokens_compressed_list,
-                        self.kv_cache_config.kv_cache_groups,
-                    ):
-                        kv_cache_spec = kv_cache_group.kv_cache_spec
-                        if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
-                            kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
-                        if getattr(kv_cache_spec, "compress_ratio", 1) > 1 and np.any(compressed_counts > 0):
-                            return True
-                    return False
-
+                (
+                    compressor_decode_key,
+                    compressor_decode_homogeneous,
+                ) = self._get_compressor_decode_key(
+                    num_scheduled_tokens_compressed_list,
+                    num_reqs,
+                )
+                has_compressor_decode_tokens = (
+                    compressor_decode_key is not None
+                    and any(count > 0 for count in compressor_decode_key)
+                )
+                compressor_decode_graphable = (
+                    has_compressor_decode_tokens
+                    and not self.with_prefill
+                    and compressor_decode_homogeneous
+                    and compressor_decode_key in self._compressor_decode_graph_keys()
+                    and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+                )
+                graph_compressor_decode_key = (
+                    compressor_decode_key if compressor_decode_graphable else None
+                )
                 force_eager_for_compressor_decode = (
                     self.use_compress
                     and not self.with_prefill
-                    and _has_new_compressed_tokens()
+                    and has_compressor_decode_tokens
+                    and not compressor_decode_graphable
                 )
 
                 (
@@ -1269,6 +1391,7 @@ class NPUModelRunner(GPUModelRunner):
                     use_cascade_attn=cascade_attn_prefix_lens is not None,
                     force_eager=self.model_config.enforce_eager or force_eager_for_compressor_decode,
                     num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
+                    compressor_decode_key=graph_compressor_decode_key,
                 )
 
                 logger.debug(
@@ -1964,6 +2087,7 @@ class NPUModelRunner(GPUModelRunner):
         force_has_lora: bool | None = None,
         force_num_active_loras: int | None = None,
         num_encoder_reqs: int = 0,
+        compressor_decode_key: tuple[int, ...] | None = None,
     ) -> tuple[CUDAGraphMode, BatchDescriptor, bool, torch.Tensor | None, CUDAGraphStat | None]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
@@ -2028,6 +2152,11 @@ class NPUModelRunner(GPUModelRunner):
                 # Assert to make sure the agreed upon token count is correct otherwise
                 # num_tokens_across_dp will no-longer be valid
                 assert batch_descriptor.num_tokens == num_tokens_padded
+        if compressor_decode_key is not None and cudagraph_mode == CUDAGraphMode.FULL:
+            batch_descriptor = AscendBatchDescriptor.from_batch_descriptor(
+                batch_descriptor,
+                compressor_decode_key,
+            )
         cudagraph_stats = None
         if self.vllm_config.observability_config.cudagraph_metrics:
             cudagraph_stats = CUDAGraphStat(
@@ -2368,6 +2497,7 @@ class NPUModelRunner(GPUModelRunner):
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        compressor_decode_key: tuple[int, ...] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -2431,6 +2561,7 @@ class NPUModelRunner(GPUModelRunner):
             # LoRA state when determining the batch descriptor for capture
             force_has_lora=num_active_loras > 0,
             force_num_active_loras=num_active_loras,
+            compressor_decode_key=compressor_decode_key,
         )
         if self.use_cp:
             self.pcp_manager.init_batch_info(
@@ -2482,6 +2613,11 @@ class NPUModelRunner(GPUModelRunner):
                     if is_graph_capturing and using_paged_attention(num_tokens, self.vllm_config)
                     else max_query_len
                 )  # type: ignore[assignment]
+            dummy_compressor_decode_position = self._dummy_compressor_decode_position(
+                compressor_decode_key
+            )
+            if compressor_decode_key is not None:
+                seq_lens = max(seq_lens, dummy_compressor_decode_position + 1)
             self.seq_lens.np[:num_reqs_padded] = seq_lens
             self.seq_lens.np[num_reqs_padded:] = 0
             self.seq_lens.copy_to_gpu()
@@ -2496,9 +2632,7 @@ class NPUModelRunner(GPUModelRunner):
             pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
             # check how to build dummy
             if self.use_compress:
-                # Capture the common non-boundary compressed-decode graph
-                # without the compressor op. Boundary steps force eager.
-                self.positions.np.fill(0)
+                self.positions.np.fill(dummy_compressor_decode_position)
                 self.positions.copy_to_gpu()
             attn_metadata, _ = self._build_attention_metadata(
                 num_tokens=num_tokens_unpadded,
@@ -2618,6 +2752,63 @@ class NPUModelRunner(GPUModelRunner):
                 self.positions.copy_to_gpu()
 
             return hidden_states, hidden_states
+
+    def _warmup_and_capture(
+        self,
+        desc: BatchDescriptor,
+        cudagraph_runtime_mode: CUDAGraphMode,
+        profile_seq_lens: int | None = None,
+        allow_microbatching: bool = False,
+        num_warmups: int | None = None,
+    ):
+        super()._warmup_and_capture(
+            desc,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            profile_seq_lens=profile_seq_lens,
+            allow_microbatching=allow_microbatching,
+            num_warmups=num_warmups,
+        )
+
+        if (
+            not self.use_compress
+            or cudagraph_runtime_mode != CUDAGraphMode.FULL
+            or not desc.uniform
+        ):
+            return
+
+        compressor_decode_keys = self._compressor_decode_graph_keys()
+        if not compressor_decode_keys:
+            return
+
+        if num_warmups is None:
+            num_warmups = self.compilation_config.cudagraph_num_of_warmups
+        force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
+
+        for compressor_decode_key in sorted(compressor_decode_keys):
+            for _ in range(num_warmups):
+                self._dummy_run(
+                    desc.num_tokens,
+                    cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                    force_attention=force_attention,
+                    uniform_decode=desc.uniform,
+                    allow_microbatching=allow_microbatching,
+                    skip_eplb=True,
+                    remove_lora=False,
+                    num_active_loras=desc.num_active_loras,
+                    compressor_decode_key=compressor_decode_key,
+                )
+            self._dummy_run(
+                desc.num_tokens,
+                cudagraph_runtime_mode=cudagraph_runtime_mode,
+                uniform_decode=desc.uniform,
+                allow_microbatching=allow_microbatching,
+                skip_eplb=True,
+                remove_lora=False,
+                num_active_loras=desc.num_active_loras,
+                is_graph_capturing=True,
+                profile_seq_lens=profile_seq_lens,
+                compressor_decode_key=compressor_decode_key,
+            )
 
     @torch.inference_mode()
     def _dummy_sampler_run(


### PR DESCRIPTION
### What this PR does / why we need it?

DSv4 decode 阶段，当 compress_ratio > 1 的层在某些 step（如 prefix cache 命中、纯采样无新增 compressed token 等）实际上没有新 token 需要进 Compressor，但当前代码仍会无条件执行 `torch.ops._C_ascend.compressor` + `npu_scatter_nd_update_v2` 写 KV cache。这两个调用在无新 token 时是**完全冗余**的：
- `compressor` 算子有 launch + tiling overhead
- `scatter_nd_update_v2` 写空 slot_mapping 会触发空操作但 launch 开销仍在
- aclgraph 重放时这两个无效算子持续累积时间

本 PR 在 decode 阶段加判断，跳过这两个无效调用。

### Modifications

**1. `vllm_ascend/attention/dsa_v1.py`**（57 +49 -）

在 `AscendDSAImpl` decode 路径（`compress_ratio > 1` 分支）中：

```python
has_compressor_decode_tokens = (
    compressor_attn_metadata.decode.slot_mapping.numel() > 0)
...
if has_compressor_decode_tokens:
    compressed_kv = torch.ops._C_ascend.compressor(...)
    torch.ops._C_ascend.npu_scatter_nd_update_v2(compress_kv_cache, ..., compressed_kv)
# 否则跳过整段
```

**2. `vllm_ascend/worker/model_runner_v1.py`**（+24 -2）

新增 `_has_new_compressed_tokens()` 辅助方法：遍历所有 kv_cache_groups，检测有 `compress_ratio > 1` 的层是否真的有新 compressed token。

当 `use_compress=True` 且 decode 阶段无新 compressed token 时，强制 `force_eager=True`，避免 aclgraph 捕获到包含冗余 compressor 调用的 graph 后无法跳过这两个算子。

### Effect

- **decode 阶段无新 compressed token 的 step**（prefix cache 命中、特殊采样路径等）跳过 compressor 调用
- 单层节省 1 次 compressor 算子 + 1 次 scatter_nd_update_v2 launch
- 单 step 节省 ≈ 每层 50-100 μs（含 launch + tiling），对 DSv4 61 层 × compress_ratio>1 层数（典型 40+ 层）累积可观
- 与 `multistream_dsa_preprocess` / aclgraph 路径都兼容

### Compatibility

- 仅影响 `use_compress=True` 时的 decode 路径
- Prefill / `compress_ratio=1` 层完全不受影响
- 不改变 KV cache 内容（写入语义保持）

### Testing

- [ ] A3 单机 TP8 DP2 EP=16 decode（含 / 不含 aclgraph）
- [ ] 长 prompt + prefix cache 命中场景验证跳过路径
- [ ] msprof 验证 compressor 算子调用次数下降
- [ ] C-Eval / MMLU 精度无回归