### PR TITLE
feat(kv-pool): add hybrid KV cache groups support

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -10,7 +10,12 @@ from vllm.distributed.kv_events import (
     KVConnectorKVEvents,
     KVEventAggregator,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+    SupportsHMA,
+)
 from vllm.forward_context import ForwardContext
 from vllm.logger import logger
 from vllm.utils.network_utils import make_zmq_socket
@@ -63,7 +68,15 @@ class AscendStoreKVEvents(KVConnectorKVEvents):
         return f"<AscendStoreKVEvents events={self.get_all_events()}>"
 
 
-class AscendStoreConnector(KVConnectorBase_V1):
+class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
+        """
+        AscendStore requires PIECEWISE CUDA graph mode when layerwise
+        operations are enabled.
+        """
+        return extra_config.get("use_layerwise", False)
+
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole, kv_cache_config: KVCacheConfig | None = None):
         super().__init__(vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config)
         self.kv_role = vllm_config.kv_transfer_config.kv_role
@@ -86,11 +99,12 @@ class AscendStoreConnector(KVConnectorBase_V1):
         self.sended_but_unfinished_reqs: set[str] = set()
 
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler = KVPoolScheduler(vllm_config, self.use_layerwise)
+            self.connector_scheduler = KVPoolScheduler(vllm_config, self.use_layerwise, kv_cache_config)
         else:
             self.connector_worker = KVPoolWorker(
                 vllm_config,
                 self.use_layerwise,
+                kv_cache_config,
             )
 
             assert self.connector_worker is not None
@@ -123,6 +137,14 @@ class AscendStoreConnector(KVConnectorBase_V1):
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished_all_groups(request, block_ids)
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
         """
@@ -166,7 +188,21 @@ class AscendStoreConnector(KVConnectorBase_V1):
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
-        self.connector_worker.start_load_kv(self._get_connector_metadata())
+        metadata = self._get_connector_metadata()
+        logger.info(
+            "KV pool connector start_load_kv metadata_requests=%d specs=%s",
+            len(metadata.requests),
+            [
+                (
+                    request.req_id,
+                    None if request.load_spec is None else request.load_spec.can_load,
+                    None if request.load_spec is None else request.load_spec.vllm_cached_tokens,
+                    None if request.load_spec is None else request.load_spec.kvpool_cached_tokens,
+                )
+                for request in metadata.requests
+            ],
+        )
+        self.connector_worker.start_load_kv(metadata)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         if not self.use_layerwise:
@@ -241,9 +277,21 @@ class LookupKeyServer:
             while self.running:
                 all_frames = self.socket.recv_multipart(copy=False)
                 token_len = int.from_bytes(all_frames[0], byteorder="big")
-                hash_frames = all_frames[1:]
+                kv_group_ids = self.decoder.decode([all_frames[1]])
+                hash_frames = all_frames[2:]
                 hashes_str = self.decoder.decode(hash_frames)
-                result = self.pool_worker.lookup_scheduler(token_len, hashes_str, self.use_layerwise)
+                result = self.pool_worker.lookup_scheduler(
+                    token_len,
+                    hashes_str,
+                    kv_group_ids,
+                    self.use_layerwise,
+                )
+                logger.info(
+                    "KV pool lookup response token_len=%d groups=%s hit_tokens=%d",
+                    token_len,
+                    kv_group_ids,
+                    result,
+                )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -2,6 +2,7 @@
 import json
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import regex as re
 import torch
@@ -88,11 +89,23 @@ class MooncakeBackend(Backend):
             logger.error(f"Failed to put key {keys},error:{e}")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+        logger.info(
+            "MooncakeBackend.get enter keys=%d sample_keys=%s",
+            len(keys),
+            keys[:3],
+        )
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
-            for value in res:
+            res_list = list(res)
+            logger.info(
+                "MooncakeBackend.get result keys=%d result_sample=%s negative_count=%d",
+                len(keys),
+                res_list[:12],
+                sum(1 for value in res_list if value < 0),
+            )
+            for value in res_list:
                 if value < 0:
-                    logger.error(f"Failed to get key {keys}, res:{res}")
+                    logger.error(f"Failed to get key {keys}, res:{res_list}")
         except Exception as e:
             logger.error(f"Failed to get key {keys}, error:{e}")
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,12 +1,14 @@
-from collections.abc import Iterable
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional, cast
 
 import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList, BlockHashListWithBlockSize
 from vllm.v1.core.sched.output import NewRequestData
 
 
@@ -24,6 +26,12 @@ class KeyMetadata:
     dcp_rank: int
     """ Initialize the current pipeline parallel rank """
     pp_rank: int
+    """ Initialize the current kv cache group id """
+    kv_cache_group_id: int = 0
+    """ Differentiate kv/state keys that share the same chunk hash """
+    cache_role: str = "kv"
+    """ Family name for compress-aware hybrid cache layouts """
+    cache_family: str = "default"
 
 
 @dataclass(order=True)
@@ -39,6 +47,9 @@ class PoolKey:
                 self.key_metadata.pcp_rank,
                 self.key_metadata.dcp_rank,
                 self.key_metadata.pp_rank,
+                self.key_metadata.kv_cache_group_id,
+                self.key_metadata.cache_role,
+                self.key_metadata.cache_family,
                 self.chunk_hash,
             )
         )
@@ -48,7 +59,11 @@ class PoolKey:
             f"{self.key_metadata.model_name}"
             f"@pcp{self.key_metadata.pcp_rank}@dcp{self.key_metadata.dcp_rank}"
             f"@head_or_tp_rank:{self.key_metadata.head_or_tp_rank}"
-            f"@pp_rank:{self.key_metadata.pp_rank}@{self.chunk_hash}"
+            f"@pp_rank:{self.key_metadata.pp_rank}"
+            f"@group:{self.key_metadata.kv_cache_group_id}"
+            f"@cache_role:{self.key_metadata.cache_role}"
+            f"@cache_family:{self.key_metadata.cache_family}"
+            f"@{self.chunk_hash}"
         )
 
     def split_layers(self, num_layers: int) -> list["LayerPoolKey"]:
@@ -78,6 +93,9 @@ class LayerPoolKey(PoolKey):
                 self.key_metadata.head_or_tp_rank,
                 self.key_metadata.pcp_rank,
                 self.key_metadata.dcp_rank,
+                self.key_metadata.kv_cache_group_id,
+                self.key_metadata.cache_role,
+                self.key_metadata.cache_family,
                 self.chunk_hash,
                 self.layer_id,
             )
@@ -87,22 +105,153 @@ class LayerPoolKey(PoolKey):
         return (
             f"{self.key_metadata.model_name}"
             f"@pcp{self.key_metadata.pcp_rank}@dcp{self.key_metadata.dcp_rank}"
-            f"@head_or_tp_rank:{self.key_metadata.head_or_tp_rank}@{self.chunk_hash}@{self.layer_id}"
+            f"@head_or_tp_rank:{self.key_metadata.head_or_tp_rank}"
+            f"@group:{self.key_metadata.kv_cache_group_id}"
+            f"@cache_role:{self.key_metadata.cache_role}"
+            f"@cache_family:{self.key_metadata.cache_family}"
+            f"@{self.chunk_hash}@{self.layer_id}"
         )
 
 
+def infer_cache_family_from_ratio(compress_ratio: int | None) -> str:
+    if compress_ratio is None:
+        return "default"
+    if compress_ratio <= 1:
+        return "c1"
+    return f"c{compress_ratio}"
+
+
+def infer_cache_family_ratio(cache_family: str | None) -> int:
+    if not cache_family or not cache_family.startswith("c"):
+        return 1
+    ratio = cache_family[1:]
+    return int(ratio) if ratio.isdigit() else 1
+
+
+def get_cache_family_granularity(block_size: int, cache_family: str | None) -> int:
+    return block_size * infer_cache_family_ratio(cache_family)
+
+
+def _get_layer_compress_ratio(
+    layer_name: str,
+    compress_ratios: Sequence[int] | None,
+    hf_config: Any | None = None,
+) -> int | None:
+    if compress_ratios is None:
+        return None
+    if getattr(hf_config, "model_type", None) == "deepseek_v4":
+        from vllm_ascend.utils import extract_dsv4_layer_index, get_dsv4_compress_ratio
+
+        return get_dsv4_compress_ratio(hf_config, extract_dsv4_layer_index(hf_config, layer_name))
+    from vllm.model_executor.models.utils import extract_layer_index
+
+    return compress_ratios[extract_layer_index(layer_name)]
+
+
+def _get_group_spec_ratios(group: object) -> set[int | None]:
+    kv_cache_spec = getattr(group, "kv_cache_spec", None)
+    if kv_cache_spec is None:
+        return set()
+    kv_cache_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+    if kv_cache_specs is not None:
+        return {
+            getattr(spec, "compress_ratio", None)
+            for spec in kv_cache_specs.values()
+        }
+    return {getattr(kv_cache_spec, "compress_ratio", None)}
+
+
+def infer_group_cache_families(
+    kv_cache_groups: Sequence[object] | None,
+    compress_ratios: Sequence[int] | None,
+    hf_config: Any | None = None,
+) -> list[str]:
+    if kv_cache_groups is None:
+        return ["default"]
+
+    families: list[str] = []
+    for group in kv_cache_groups:
+        spec_ratios = _get_group_spec_ratios(group)
+        if len(spec_ratios) == 1:
+            families.append(infer_cache_family_from_ratio(next(iter(spec_ratios))))
+            continue
+        if len(spec_ratios) > 1:
+            families.append("mixed")
+            continue
+
+        layer_names = list(getattr(group, "layer_names", []))
+        if compress_ratios is None or not layer_names:
+            families.append("default")
+            continue
+
+        group_ratios = {
+            _get_layer_compress_ratio(layer_name, compress_ratios, hf_config)
+            for layer_name in layer_names
+        }
+        if len(group_ratios) == 1:
+            families.append(infer_cache_family_from_ratio(next(iter(group_ratios))))
+        else:
+            logger.debug(
+                "KV cache group has mixed layer compress ratios %s for layers %s; "
+                "using mixed cache family.",
+                sorted(group_ratios),
+                layer_names,
+            )
+            families.append("mixed")
+    return families
+
+
 class ChunkedTokenDatabase:
-    def __init__(self, metadata: KeyMetadata, block_size: int, partitions: list[int] | None):
+    def __init__(
+        self,
+        metadata: KeyMetadata,
+        block_size: int | list[int],
+        partitions: list[int] | None,
+        use_hybrid: bool = False,
+        hash_block_size: int | None = None,
+    ):
         self.metadata = metadata
-        self.block_size = block_size
+        self.block_size = block_size if isinstance(block_size, list) else [block_size]
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
+        self.block_stride: list[int] = []
+        self.group_kv_caches_base_addr: dict[int, list[int]] = {}
+        self.group_block_len: dict[int, list[int]] = {}
+        self.group_block_stride: dict[int, list[int]] = {}
+        self.group_cache_families: dict[str, dict[int, str]] = {
+            "kv": {},
+            "state": {},
+        }
+        self.group_num_layers: dict[str, dict[int, int]] = {
+            "kv": {},
+            "state": {},
+        }
         self.partitions = partitions
+        self.use_hybrid = use_hybrid
+        self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
 
-    def _make_key_by_hash(self, chunk_hash: str, layer_id: int | None = None):
+    def _make_key_by_hash(
+        self,
+        chunk_hash: str,
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        layer_id: int | None = None,
+    ):
         assert self.metadata is not None
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
         return PoolKey(
-            self.metadata,
+            KeyMetadata(
+                model_name=self.metadata.model_name,
+                head_or_tp_rank=self.metadata.head_or_tp_rank,
+                pcp_rank=self.metadata.pcp_rank,
+                dcp_rank=self.metadata.dcp_rank,
+                pp_rank=self.metadata.pp_rank,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                cache_family=cache_family,
+            ),
             chunk_hash,
         )
 
@@ -112,26 +261,80 @@ class ChunkedTokenDatabase:
     def set_block_len(self, block_len: list[int]):
         self.block_len = block_len
 
-    def prepare_value(self, start: int, end: int, block_ids: list[int]):
+    def set_block_stride(self, block_stride: list[int]):
+        self.block_stride = block_stride
+
+    def get_block_size(self, kv_cache_group_id: int) -> int:
+        if kv_cache_group_id >= len(self.block_size):
+            return self.block_size[0]
+        return self.block_size[kv_cache_group_id]
+
+    def set_group_buffers(
+        self,
+        group_kv_caches_base_addr: dict[int, list[int]],
+        group_block_len: dict[int, list[int]],
+        group_block_stride: dict[int, list[int]] | None = None,
+        cache_role: str = "kv",
+        group_cache_families: dict[int, str] | None = None,
+        group_num_layers: dict[int, int] | None = None,
+    ) -> None:
+        if cache_role == "state":
+            # Keep the interface for future explicit state groups, but this
+            # DSV4 branch stores compressor/indexer states in kv_caches.
+            pass
+        else:
+            self.group_kv_caches_base_addr = group_kv_caches_base_addr
+            self.group_block_len = group_block_len
+            self.group_block_stride = group_block_stride or {}
+        if group_cache_families is not None:
+            self.group_cache_families[cache_role] = group_cache_families.copy()
+        if group_num_layers is not None:
+            self.group_num_layers[cache_role] = group_num_layers.copy()
+
+    def _get_group_buffers(self, kv_cache_group_id: int, cache_role: str) -> tuple[list[int], list[int], list[int]]:
+        if cache_role == "state":
+            return [], [], []
+        return (
+            self.group_kv_caches_base_addr.get(kv_cache_group_id, self.kv_caches_base_addr),
+            self.group_block_len.get(kv_cache_group_id, self.block_len),
+            self.group_block_stride.get(kv_cache_group_id, self.block_stride),
+        )
+
+    def prepare_value(
+        self,
+        start: int,
+        end: int,
+        block_ids: list[int],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+    ):
         addr_list = []
         size_list = []
-        block_id = block_ids[start // self.block_size]
-        length = len(self.block_len)
-        for index, base_addr in enumerate(self.kv_caches_base_addr):
-            addr = base_addr + block_id * self.block_len[index % length]
-            size = int(self.block_len[index % length] / self.block_size * (end - start))
+        group_block_size = self.get_block_size(kv_cache_group_id)
+        block_id = block_ids[start // group_block_size]
+        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
+        length = len(group_block_len)
+        if length == 0:
+            return addr_list, size_list, block_id
+        for index, base_addr in enumerate(group_addrs):
+            block_len = group_block_len[index % length]
+            block_stride = group_block_stride[index % length] if group_block_stride else block_len
+            addr = base_addr + block_id * block_stride
+            size = int(block_len / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list, block_id
 
     def prepare_value_layer(self, start: int, end: int, block_ids: list[int], layer_id: int):
-        block_id = block_ids[start // self.block_size]
+        group_block_size = self.get_block_size(0)
+        block_id = block_ids[start // group_block_size]
         addr_list = []
         size_list = []
         length = len(self.block_len)
         for i in range(length):
-            addr = self.kv_caches_base_addr[layer_id * length] + block_id * self.block_len[i]
-            size = int(self.block_len[i] / self.block_size * (end - start))
+            block_stride = self.block_stride[i] if self.block_stride else self.block_len[i]
+            addr = self.kv_caches_base_addr[layer_id * length + i] + block_id * block_stride
+            size = int(self.block_len[i] / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list
@@ -139,29 +342,21 @@ class ChunkedTokenDatabase:
     def process_tokens(
         self,
         token_len: int,
-        block_hashes: list[BlockHash] | list[str],
+        block_hashes: BlockHashList | list[str],
         mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
-        """Process the tokens and return the corresponding cache engine keys.
-
-        :param Union[torch.Tensor, List[int]] tokens: The tokens to process.
-
-        :param Optional[torch.Tensor] mask: The mask for the tokens. Should
-            have the same length as tokens. And the mask should ALWAYS be like
-            FFFFFTTTTTTT, where True means the tokens needs to be matched,
-            and the Falses will ALWAYS be at the PREFIX of the tensor.
-
-        :param bool make_key: Whether to make the cache engine key or not.
-            If False, the hash value will be returned instead.
-
-        :returns: A iterable of tuples with three elements. The first element
-            is the start index of the tokens for the key. The second element
-            is the end index of the tokens for the key. The third element is
-            the cache engine key (or hash) for the tokens.
-
-        :raises: ValueError if the number of Falses in the mask is not a
-            multiple of the chunk size.
-        """
+        """Process the tokens and return the corresponding cache engine keys."""
+        if not block_hashes:
+            return
+        group_block_size = self.get_block_size(kv_cache_group_id)
+        block_hashes = get_block_hashes(
+            block_hashes,
+            group_block_size,
+            self.hash_block_size,
+        )
         if not block_hashes:
             return
         if not isinstance(block_hashes[0], str):
@@ -171,16 +366,52 @@ class ChunkedTokenDatabase:
             ]
         start_idx = 0
         for chunk_id, hash_val in enumerate(block_hashes):
-            start_idx = chunk_id * self.block_size
+            start_idx = chunk_id * group_block_size
             if start_idx >= token_len:
                 break
-            end_idx = min(start_idx + self.block_size, token_len)
+            end_idx = min(start_idx + group_block_size, token_len)
             if start_idx < mask_num:
                 continue
             else:
-                yield start_idx, end_idx, self._make_key_by_hash(hash_val)
+                yield (
+                    start_idx,
+                    end_idx,
+                    self._make_key_by_hash(
+                        hash_val,
+                        kv_cache_group_id=kv_cache_group_id,
+                        cache_role=cache_role,
+                        cache_family=cache_family,
+                    ),
+                )
 
-    def decode_adaptor_prefill_pp(self, key, addr, size):
+    def process_tokens_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+    ) -> Iterable[tuple[int, int, PoolKey, int]]:
+        for start_idx, end_idx, key in self.process_tokens(
+            token_len,
+            block_hashes,
+            mask_num,
+            kv_cache_group_id=kv_cache_group_id,
+            cache_role=cache_role,
+            cache_family=cache_family,
+        ):
+            block_idx = start_idx // self.get_block_size(kv_cache_group_id)
+            if block_idx >= len(block_ids):
+                continue
+            block_id = block_ids[block_idx]
+            if skip_null_blocks and block_id <= 0:
+                continue
+            yield start_idx, end_idx, key, block_id
+
+    def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
         if self.partitions is None or len(self.partitions) == 1:
             return key, addr, size
 
@@ -188,11 +419,13 @@ class ChunkedTokenDatabase:
         new_addr = []
         new_size = []
 
+        group_num_layers = self.group_num_layers.get(cache_role, {}).get(kv_cache_group_id, 0)
         for i, (addr_list, size_list) in enumerate(zip(addr, size)):
+            caches_per_layer = len(addr_list) // group_num_layers if group_num_layers else 2
+            caches_per_layer = max(caches_per_layer, 1)
             start = 0
             for j, part in enumerate(self.partitions):
-                # part * 2 because addr and size contain both k and v
-                end = len(addr_list) if j == len(self.partitions) - 1 else start + part * 2
+                end = len(addr_list) if j == len(self.partitions) - 1 else start + part * caches_per_layer
                 new_str = key[i].replace(  # type: ignore[attr-defined]
                     "@pp_rank:0", f"@pp_rank:{j}", 1
                 )
@@ -201,6 +434,37 @@ class ChunkedTokenDatabase:
                 new_size.append(size_list[start:end])
                 start = end
         return new_key, new_addr, new_size
+
+
+def normalize_block_ids_by_group(block_ids: tuple[list[int], ...] | list[int] | list[list[int]]) -> list[list[int]]:
+    if isinstance(block_ids, tuple):
+        return [group.copy() for group in block_ids]
+    if isinstance(block_ids, list):
+        if not block_ids:
+            return [[]]
+        if isinstance(block_ids[0], list):
+            grouped_block_ids = cast(list[list[int]], block_ids)
+            return [group.copy() for group in grouped_block_ids]
+        flat_block_ids = cast(list[int], block_ids)
+        return [flat_block_ids.copy()]
+    raise ValueError(f"Unsupported block_ids type {type(block_ids)}")
+
+
+def get_block_hashes(
+    block_hashes: BlockHashList | list[str],
+    group_block_size: int,
+    hash_block_size: int,
+) -> BlockHashList | list[str]:
+    if group_block_size == hash_block_size:
+        return block_hashes
+    assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+    if isinstance(block_hashes[0], str):
+        scale_factor = group_block_size // hash_block_size
+        return [
+            "".join(block_hashes[idx : idx + scale_factor])
+            for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
+        ]
+    return BlockHashListWithBlockSize(block_hashes, hash_block_size, group_block_size)
 
 
 # Parameters related to the connector metadata
@@ -223,11 +487,9 @@ class RequestTracker:
 
     token_len: int
 
-    # The block ids that has been allocated so far
-    # NOTE: allocated blocks could be more than the number of tokens
-    # FIXME: need to check whether the block ids will be changed after
-    #        preemption
-    allocated_block_ids: list[int]
+    # The block ids that has been allocated so far, grouped by KV cache group.
+    # NOTE: allocated blocks could be more than the number of tokens.
+    allocated_block_ids_by_group: list[list[int]]
 
     # The number of tokens that has been savd
     num_saved_tokens: int = 0
@@ -241,27 +503,12 @@ class RequestTracker:
         new_request: "NewRequestData",
         num_tokens_to_compute: int,
     ) -> "RequestTracker":
-        """Create the request tracker from a new request.
-
-        Args:
-            new_request (NewRequestData): the new request data.
-            num_tokens_to_compute (int): the number of tokens that will
-                be 'computed', including the `num_computed_tokens` (vLLM's
-                local cache hit) and new tokens that will be scheduled.
-
-        """
-        unfolded_block_ids = []
-
-        if not isinstance(new_request.block_ids[0], list):
-            unfolded_block_ids = new_request.block_ids.copy()
-        else:
-            unfolded_block_ids = new_request.block_ids[0].copy()
-
+        """Create the request tracker from a new request."""
         return RequestTracker(
             req_id=new_request.req_id,
             token_ids=new_request.prompt_token_ids[:num_tokens_to_compute].copy(),
             token_len=num_tokens_to_compute,
-            allocated_block_ids=unfolded_block_ids,
+            allocated_block_ids_by_group=normalize_block_ids_by_group(new_request.block_ids),
             num_saved_tokens=0,
         )
 
@@ -269,18 +516,14 @@ class RequestTracker:
         self,
         new_block_ids: tuple[list[int], ...] | list[int],
     ) -> None:
-        """Update the request tracker when a running request is
-        scheduled again
-        """
-        if len(new_block_ids) == 0:
-            new_block_ids = []
-        elif isinstance(new_block_ids, tuple):
-            new_block_ids = new_block_ids[0]
-        elif isinstance(new_block_ids, list):
-            pass
-        else:
-            raise ValueError(f"Unsupported new_block_ids type {type(new_block_ids)}")
-        self.allocated_block_ids.extend(new_block_ids)
+        """Update the request tracker when a running request is scheduled again."""
+        normalized = normalize_block_ids_by_group(new_block_ids)
+        if len(normalized) > len(self.allocated_block_ids_by_group):
+            self.allocated_block_ids_by_group.extend(
+                [[] for _ in range(len(normalized) - len(self.allocated_block_ids_by_group))]
+            )
+        for group_id, ids in enumerate(normalized):
+            self.allocated_block_ids_by_group[group_id].extend(ids)
 
 
 @dataclass
@@ -290,7 +533,7 @@ class ReqMeta:
     # Number of tokens in this chunk
     token_len_chunk: int
 
-    block_ids: list[int]
+    block_ids_by_group: list[list[int]]
 
     block_hashes: list[BlockHash]
 
@@ -301,11 +544,15 @@ class ReqMeta:
     is_last_chunk: bool | None = None
 
     current_event: torch.npu.Event | None = None
+    kv_cache_group_ids: list[int] | None = None
+    kv_cache_families_by_group: list[str] | None = None
+    skip_null_blocks_by_group: list[bool] | None = None
+    disable_tp_key_sharding: bool = False
 
     # The following parameters are only used for kv event generation
     # TODO: add lora_request which used for gen lora_id/lora_name in kv event
     token_ids: list[int] | None = None
-    original_block_size: int | None = None
+    original_block_size: list[int] | None = None
 
     @staticmethod
     def from_request_tracker(
@@ -316,23 +563,10 @@ class ReqMeta:
         block_hashes: list[BlockHash] | None = None,
         is_last_chunk: bool | None = None,
         discard_partial_chunks: bool = True,
-        original_block_size: int | None = None,
+        original_block_size: list[int] | None = None,
+        kv_cache_group_families: list[str] | None = None,
     ) -> Optional["ReqMeta"]:
-        """Create the request metadata from a request tracker.
-
-        Args:
-            tracker (RequestTracker): the request tracker.
-            block_size (int): the block size in vLLM scheduler and AscendConnector.
-                If context parallelism is enabled, block_size = block_size * pcp_size * dcp_size.
-            load_spec (Optional[LoadSpec]): the load spec for KV cache loading.
-            skip_save (bool): whether to skip the save operation.
-            discard_partial_chunks (bool): whether to discard partial chunks.
-            original_block_size (int | None): the block size in vLLM worker. This is only used for kv event generation.
-
-        Returns:
-            the request metadata if we need to perform load/save
-            operations, None otherwise.
-        """
+        """Create the request metadata from a request tracker."""
         if block_hashes is None:
             block_hashes = []
         input_token_len = tracker.token_len
@@ -341,24 +575,19 @@ class ReqMeta:
         # 1. has already been saved before (num_saved_tokens > 0)
         # 2. number of unsaved tokens is not reached the chunk boundary
         chunk_boundary = cdiv(tracker.num_saved_tokens + 1, block_size) * block_size if discard_partial_chunks else 0
-        # Calculate number of tokens to save based on discard_partial_chunks
-        # setting
         num_tokens_to_save = (input_token_len // block_size * block_size) if discard_partial_chunks else input_token_len
 
         skip_save = skip_save or num_tokens_to_save < chunk_boundary
         if skip_save and load_spec is None:
             return None
 
-        # If we need to save, update the number of saved tokens
         if not skip_save:
             tracker.num_saved_tokens = num_tokens_to_save
 
-        # Get the token ids for kv event generation in kv_transfer
         token_ids = None
         if tracker.token_ids:
             token_ids = tracker.token_ids
 
-        # # For load operation: check whether the request is scheduled to load
         if load_spec is not None and load_spec.can_load:
             logger.debug(
                 "Scheduled to load %d tokens for request %s",
@@ -366,19 +595,20 @@ class ReqMeta:
                 tracker.req_id,
             )
         else:
-            # Do not load if not in `can_load` state
             load_spec = None
-        logger.debug(f"request:{tracker.req_id}, meta save spec:{not skip_save}, meta load spec:{load_spec}")
+        logger.debug("request:%s, meta save spec:%s, meta load spec:%s", tracker.req_id, not skip_save, load_spec)
         return ReqMeta(
             req_id=tracker.req_id,
             token_len_chunk=num_tokens_to_save,
-            block_ids=tracker.allocated_block_ids,
+            block_ids_by_group=tracker.allocated_block_ids_by_group,
             can_save=not skip_save,
             load_spec=load_spec,
             block_hashes=block_hashes,
             is_last_chunk=is_last_chunk,
             token_ids=token_ids,
             original_block_size=original_block_size,
+            kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
+            kv_cache_families_by_group=kv_cache_group_families,
         )
 
 
@@ -389,11 +619,7 @@ class AscendConnectorMetadata(KVConnectorMetadata):
         self.preempted_req_ids = preempted_req_ids
 
     def add_request(self, req_meta: ReqMeta) -> None:
-        """Add a request to the metadata.
-
-        Args:
-            req_meta (ReqMeta): the request metadata.
-        """
+        """Add a request to the metadata."""
         self.requests.append(req_meta)
 
 
@@ -403,7 +629,7 @@ class LayerMultiBlockReqMeta:
     keys: list[LayerPoolKey]
     starts: list[int]
     ends: list[int]
-    block_ids: list[int]
+    block_ids_by_group: list[list[int]]
     layer_id: int
     is_last_chunk: bool | None = True
     current_event: torch.npu.Event | None = None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -16,6 +16,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ChunkedTokenDatabase,
     LayerMultiBlockReqMeta,
     ReqMeta,
+    get_block_hashes,
 )
 # isort: on
 
@@ -25,7 +26,7 @@ class KVTransferThread(threading.Thread):
         self,
         m_store: Backend,
         token_database: ChunkedTokenDatabase,
-        block_size: int,
+        block_size: int | list[int],
         tp_rank: int,
         dcp_size: int,
         ready_event: threading.Event,
@@ -45,6 +46,13 @@ class KVTransferThread(threading.Thread):
         self.finished_requests: set[str] = set()
         self.kv_event_lock = threading.Lock()
         self.kv_events: list[BlockStored] = []
+
+    def _get_block_size(self, kv_cache_group_id: int = 0) -> int:
+        if isinstance(self.block_size, list):
+            if kv_cache_group_id >= len(self.block_size):
+                return self.block_size[0]
+            return self.block_size[kv_cache_group_id]
+        return self.block_size
 
     def add_request(
         self,
@@ -113,13 +121,56 @@ class KVTransferThread(threading.Thread):
             self.kv_events.clear()
         return events
 
+    @staticmethod
+    def _skip_null_blocks(req_meta: ReqMeta, group_id: int, cache_role: str = "kv") -> bool:
+        if cache_role != "kv":
+            return False
+        skip_flags = req_meta.skip_null_blocks_by_group
+        return group_id < len(skip_flags) and skip_flags[group_id] if skip_flags else False
+
+    def _process_tokens_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes,
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+    ):
+        return self.token_database.process_tokens_with_block_ids(
+            token_len,
+            block_hashes,
+            block_ids,
+            mask_num,
+            kv_cache_group_id=kv_cache_group_id,
+            skip_null_blocks=skip_null_blocks,
+            cache_role=cache_role,
+        )
+
+    def _prepare_value(
+        self,
+        start: int,
+        end: int,
+        block_ids: list[int],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+    ):
+        return self.token_database.prepare_value(
+            start,
+            end,
+            block_ids,
+            kv_cache_group_id=kv_cache_group_id,
+            cache_role=cache_role,
+        )
+
 
 class KVCacheStoreSendingThread(KVTransferThread):
     def __init__(
         self,
         m_store: Backend,
         token_database: ChunkedTokenDatabase,
-        block_size: int,
+        block_size: int | list[int],
         tp_rank: int,
         dcp_size: int,
         put_step: int,
@@ -151,88 +202,117 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.token_len_chunk
-        block_ids = req_meta.block_ids
         req_id = req_meta.req_id
         current_event = req_meta.current_event
-        starts = []
-        ends = []
-        keys = []
-        block_hashes = []
         if req_id not in self.stored_requests:
             self.request_queue.task_done()
             return
 
-        for index, (start, end, key) in enumerate(self.token_database.process_tokens(token_len, req_meta.block_hashes)):
-            starts.append(start)
-            ends.append(end)
-            keys.append(key.to_string())
-            block_hashes.append(req_meta.block_hashes[index])
+        for group_id in req_meta.kv_cache_group_ids or [0]:
+            starts = []
+            ends = []
+            keys = []
+            block_hashes = []
+            block_ids = req_meta.block_ids_by_group[group_id]
+            group_block_size = self._get_block_size(group_id)
+            group_block_hashes = get_block_hashes(
+                req_meta.block_hashes,
+                group_block_size,
+                self.token_database.hash_block_size,
+            )
 
-        if not self.dcp_size > 1:
-            starts = starts[self.tp_rank % self.put_step :: self.put_step]
-            ends = ends[self.tp_rank % self.put_step :: self.put_step]
-            keys = keys[self.tp_rank % self.put_step :: self.put_step]
-            block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
+            for start, end, key, _ in self._process_tokens_with_block_ids(
+                token_len,
+                req_meta.block_hashes,
+                block_ids,
+                kv_cache_group_id=group_id,
+                skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+            ):
+                starts.append(start)
+                ends.append(end)
+                keys.append(key.to_string())
+                block_hashes.append(group_block_hashes[start // group_block_size])
 
-        if not keys:
-            self.dec_stored_request(req_id)
-            return
+            if not self.dcp_size > 1 and not req_meta.disable_tp_key_sharding:
+                starts = starts[self.tp_rank % self.put_step :: self.put_step]
+                ends = ends[self.tp_rank % self.put_step :: self.put_step]
+                keys = keys[self.tp_rank % self.put_step :: self.put_step]
+                block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
 
-        exists_states = self.lookup(keys)
-        missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+            if not keys:
+                continue
 
-        if not missing_indices:
-            self.dec_stored_request(req_id)
-            return
+            exists_states = self.lookup(keys)
+            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
 
-        starts = [starts[index] for index in missing_indices]
-        ends = [ends[index] for index in missing_indices]
-        keys = [keys[index] for index in missing_indices]
-        block_hashes = [block_hashes[index] for index in missing_indices]
+            if not missing_indices:
+                continue
 
-        logger.debug(
-            "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s",
-            len(keys),
-            token_len // self.block_size,
-            len(missing_indices),
-            req_id,
-        )
+            starts = [starts[index] for index in missing_indices]
+            ends = [ends[index] for index in missing_indices]
+            keys = [keys[index] for index in missing_indices]
+            block_hashes = [block_hashes[index] for index in missing_indices]
 
-        if keys:
-            """
-            Note: Due to a bug in ADXL, calling current_event.synchronize() may occasionally hang.
-            This issue will be fixed in CANN version 8.5.rc1.
-            You can manually build the master branch of the project at https://gitcode.com/cann/hixl
-            to resolve this issue before the 8.5.RC1 release.
-            """
+            logger.debug(
+                "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
+                len(keys),
+                token_len // group_block_size,
+                len(missing_indices),
+                req_id,
+                group_id,
+            )
+            logger.info(
+                "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
+                req_id,
+                group_id,
+                token_len,
+                len(keys),
+                keys[:3],
+            )
+
             addrs = []
             sizes = []
             stored_events: list[BlockStored] = []
             prev_key = None
             new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
             for index, start in enumerate(starts):
-                addr, size, _ = self.token_database.prepare_value(start, ends[index], block_ids)
+                addr, size, _ = self._prepare_value(
+                    start,
+                    ends[index],
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                )
                 addrs.append(addr)
                 sizes.append(size)
 
                 # Create KV event
                 if self.enable_kv_event:
                     token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
+                    block_size = (
+                        req_meta.original_block_size[group_id]
+                        if isinstance(req_meta.original_block_size, list)
+                        else req_meta.original_block_size
+                    )
                     stored_event = BlockStored(
                         block_hashes=[new_block_hashes[index]],
                         parent_block_hash=prev_key,
                         token_ids=token_ids,
-                        block_size=req_meta.original_block_size,
+                        block_size=block_size,
                         lora_id=None,
                         medium="cpu",
                         lora_name=None,
                     )
                     stored_events.append(stored_event)
                     prev_key = new_block_hashes[index]
-                    logger.debug(f"Added kv cache event '{stored_event}' to kv cache events queue")
+                    logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
             if self.kv_role == "kv_consumer":
-                keys, addrs, sizes = self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
+                keys, addrs, sizes = self.token_database.decode_adaptor_prefill_pp(
+                    keys,
+                    addrs,
+                    sizes,
+                    kv_cache_group_id=group_id,
+                )
 
             if current_event is not None:
                 current_event.synchronize()
@@ -251,7 +331,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         self,
         m_store: Backend,
         token_database: ChunkedTokenDatabase,
-        block_size: int,
+        block_size: int | list[int],
         tp_rank: int,
         dcp_size: int,
         ready_event: threading.Event,
@@ -263,23 +343,58 @@ class KVCacheStoreRecvingThread(KVTransferThread):
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
         req_id = req_meta.req_id
-        mask_num = (
-            req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size
-            * self.block_size
-        )
         addr_list = []
         size_list = []
         key_list = []
-        for start, end, key in self.token_database.process_tokens(token_len, req_meta.block_hashes, mask_num):
-            addr, size, _ = self.token_database.prepare_value(start, end, req_meta.block_ids)
-            key_list.append(key.to_string())
-            addr_list.append(addr)
-            size_list.append(size)
+        for group_id in req_meta.kv_cache_group_ids or [0]:
+            block_ids = req_meta.block_ids_by_group[group_id]
+            group_block_size = self._get_block_size(group_id)
+            mask_num = (
+                req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
+                // group_block_size
+                * group_block_size
+            )
+            for start, end, key, _ in self._process_tokens_with_block_ids(
+                token_len,
+                req_meta.block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=group_id,
+                skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+            ):
+                addr, size, _ = self._prepare_value(
+                    start,
+                    end,
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                key_list.append(key.to_string())
+                addr_list.append(addr)
+                size_list.append(size)
+        if not key_list:
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
         key_list_c = key_list[self.tp_rank % len(key_list) :] + key_list[: self.tp_rank % len(key_list)]
         addr_list_c = addr_list[self.tp_rank % len(addr_list) :] + addr_list[: self.tp_rank % len(addr_list)]
         size_list_c = size_list[self.tp_rank % len(size_list) :] + size_list[: self.tp_rank % len(size_list)]
+        logger.info(
+            "KV pool async recv calls backend get request=%s token_len=%d groups=%s "
+            "keys=%d sample_keys=%s",
+            req_id,
+            token_len,
+            req_meta.kv_cache_group_ids or [0],
+            len(key_list_c),
+            key_list_c[:3],
+        )
         self.m_store.get(key_list_c, addr_list_c, size_list_c)
+        logger.info(
+            "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
+            req_id,
+            token_len,
+            req_meta.kv_cache_group_ids or [0],
+            len(key_list_c),
+        )
         self.set_finished_request(req_id)
         self.request_queue.task_done()
 
@@ -289,7 +404,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self,
         m_store: Backend,
         token_database: ChunkedTokenDatabase,
-        block_size: int,
+        block_size: int | list[int],
         tp_rank: int,
         dcp_size: int,
         put_step: int,
@@ -349,7 +464,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         size_list = []
         for index, key in enumerate(key_list):
             addr, size = self.token_database.prepare_value_layer(
-                starts[index], ends[index], req_meta.block_ids, layer_id
+                starts[index], ends[index], req_meta.block_ids_by_group[0], layer_id
             )
             addr_list.append(addr)
             size_list.append(size)
@@ -376,7 +491,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         self,
         m_store: Backend,
         token_database: ChunkedTokenDatabase,
-        block_size: int,
+        block_size: int | list[int],
         tp_rank: int,
         dcp_size: int,
         ready_event: threading.Event,
@@ -400,7 +515,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         key_list = []
         for index, key in enumerate(req_meta.keys):
             addr, size = self.token_database.prepare_value_layer(
-                req_meta.starts[index], req_meta.ends[index], req_meta.block_ids, req_meta.layer_id
+                req_meta.starts[index], req_meta.ends[index], req_meta.block_ids_by_group[0], req_meta.layer_id
             )
             key_list.append(key.to_string())
             addr_list.append(addr)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any
 
 import vllm.envs as envs
@@ -5,10 +6,18 @@ import zmq
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    MambaSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackEncoder
 
@@ -17,12 +26,48 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LoadSpec,
     ReqMeta,
     RequestTracker,
+    get_cache_family_granularity,
+    infer_group_cache_families,
+    normalize_block_ids_by_group,
 )
 
 
 class KVPoolScheduler:
-    def __init__(self, vllm_config: "VllmConfig", use_layerwise):
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        use_layerwise,
+        kv_cache_config: KVCacheConfig | None = None,
+    ):
         self.use_layerwise = use_layerwise
+        self.kv_cache_config = kv_cache_config
+        hf_text_config = getattr(vllm_config.model_config, "hf_text_config", None)
+        hf_config = getattr(vllm_config.model_config, "hf_config", hf_text_config)
+        self.hf_config = hf_text_config or hf_config
+        self.compress_ratios = getattr(hf_text_config, "compress_ratios", None)
+        if self.compress_ratios is None:
+            self.compress_ratios = getattr(hf_config, "compress_ratios", None)
+        self.use_compress = self.compress_ratios is not None
+        self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
+        self.kv_cache_group_ids = (
+            list(range(len(kv_cache_config.kv_cache_groups)))
+            if kv_cache_config is not None and self.use_hybrid
+            else [0]
+        )
+        self.kv_cache_group_families = self._infer_group_families()
+        self.need_truncate = self.use_compress
+        self.num_swa_blocks = self._infer_swa_blocks()
+        if kv_cache_config is not None:
+            for kv_cache_group in kv_cache_config.kv_cache_groups:
+                kv_cache_spec = kv_cache_group.kv_cache_spec
+                if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                    kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+                if isinstance(kv_cache_spec, MambaSpec) and getattr(kv_cache_spec, "mamba_cache_mode", None) != "align":
+                    raise NotImplementedError(
+                        "AscendStore hybrid linear-attention support currently requires mamba_cache_mode='align'."
+                    )
+        if self.use_layerwise and len(self.kv_cache_group_ids) > 1:
+            raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.consumer_is_to_load = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "consumer_is_to_load", False
@@ -37,12 +82,20 @@ class KVPoolScheduler:
         self.pcp_size = getattr(vllm_config.parallel_config, "prefill_context_parallel_size", 1)
         self.dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
 
-        self.original_block_size = vllm_config.cache_config.block_size
-        self._block_size = vllm_config.cache_config.block_size
-        if self.pcp_size > 1:
-            self._block_size *= self.pcp_size
-        if self.dcp_size > 1:
-            self._block_size *= self.dcp_size
+        self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
+        cp_scale = self.pcp_size * self.dcp_size
+        self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
+        requested_hash_block_size = vllm_config.cache_config.hash_block_size
+        self.hash_block_size = (
+            requested_hash_block_size
+            if requested_hash_block_size is not None
+            else min(self.original_block_size)
+        ) * cp_scale
+        for group_block_size in self.grouped_block_size:
+            assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
+        self._block_size = self.grouped_block_size[0]
+        self.lcm_block_size = math.lcm(*self.grouped_block_size)
+        self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
         # request_id -> full_token_ids
         self._request_trackers: dict[str, RequestTracker] = {}
         self._preempted_req_ids: set[str] = set()
@@ -50,8 +103,100 @@ class KVPoolScheduler:
         self._discard_partial_chunks = vllm_config.kv_transfer_config.get_from_extra_config(
             "discard_partial_chunks", True
         )
-        self._unfinished_requests: dict[str, tuple[Request, list[int]]] = {}
+        self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._unfinished_request_ids: set[str] = set()
+
+    def _infer_group_families(self) -> list[str]:
+        kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
+        return infer_group_cache_families(kv_cache_groups, self.compress_ratios, self.hf_config)
+
+    def _infer_group_block_sizes(
+        self,
+        vllm_config: "VllmConfig",
+        kv_cache_config: KVCacheConfig | None,
+    ) -> list[int]:
+        if kv_cache_config is None or not self.use_hybrid:
+            return [vllm_config.cache_config.block_size]
+
+        block_sizes: list[int] = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+            block_sizes.append(kv_cache_spec.block_size)
+        return block_sizes
+
+    def _get_group_block_size(self, group_id: int) -> int:
+        if group_id >= len(self.grouped_block_size):
+            return self.grouped_block_size[0]
+        return self.grouped_block_size[group_id]
+
+    def _get_group_family(self, families: list[str], group_id: int) -> str:
+        if group_id >= len(families):
+            return "default"
+        return families[group_id]
+
+    def _infer_cache_transfer_granularity(self) -> int:
+        granularities = [self.lcm_block_size]
+        for group_id in self.kv_cache_group_ids:
+            granularities.append(
+                get_cache_family_granularity(
+                    self._get_group_block_size(group_id),
+                    self._get_group_family(self.kv_cache_group_families, group_id),
+                )
+            )
+        return math.lcm(*granularities)
+
+    def _floor_to_cache_transfer_granularity(self, token_len: int) -> int:
+        return token_len // self.cache_transfer_granularity * self.cache_transfer_granularity
+
+    @staticmethod
+    def _uses_hybrid_kv_cache(vllm_config: "VllmConfig", kv_cache_config: KVCacheConfig | None) -> bool:
+        if kv_cache_config is None:
+            return False
+        if getattr(vllm_config.scheduler_config, "disable_hybrid_kv_cache_manager", False):
+            return False
+        return len(kv_cache_config.kv_cache_groups) > 1 and any(
+            not isinstance(group.kv_cache_spec, FullAttentionSpec) for group in kv_cache_config.kv_cache_groups
+        )
+
+    def _infer_swa_blocks(self) -> list[int]:
+        if self.kv_cache_config is None:
+            return []
+
+        num_swa_blocks: list[int] = []
+        for group in self.kv_cache_config.kv_cache_groups:
+            kv_cache_spec = group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                group_specs = []
+                for layer_name in group.layer_names:
+                    layer_spec = kv_cache_spec.kv_cache_specs[layer_name]
+                    if layer_spec not in group_specs:
+                        group_specs.append(layer_spec)
+            else:
+                group_specs = [kv_cache_spec]
+
+            first_spec = group_specs[0]
+            if isinstance(first_spec, SlidingWindowSpec):
+                num_swa_blocks.append(cdiv(first_spec.sliding_window, first_spec.block_size) + 1)
+            else:
+                num_swa_blocks.append(0)
+            if any(isinstance(spec, MambaSpec) for spec in group_specs):
+                self.need_truncate = True
+        return num_swa_blocks
+
+    def get_sw_clipped_blocks(
+        self,
+        block_ids: tuple[list[int], ...] | list[list[int]],
+    ) -> tuple[list[int], ...] | list[list[int]]:
+        if len(block_ids) == 0 or not self.use_hybrid:
+            return block_ids
+        assert len(block_ids) == len(self.num_swa_blocks), "Number of KV cache groups must match"
+        clipped = [
+            blocks[-self.num_swa_blocks[group_id] :] if self.num_swa_blocks[group_id] > 0 else blocks
+            for group_id, blocks in enumerate(block_ids)
+        ]
+        return tuple(clipped) if isinstance(block_ids, tuple) else clipped
 
     def get_num_new_matched_tokens(
         self,
@@ -74,14 +219,18 @@ class KVPoolScheduler:
             return 0, False
 
         if self._discard_partial_chunks:
-            token_len = len(request.prompt_token_ids) // self._block_size * self._block_size
+            token_len = self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
         else:
             token_len = len(request.prompt_token_ids)
 
-        if token_len < self._block_size:
+        if token_len < self.cache_transfer_granularity:
             return 0, False
 
-        num_external_hit_tokens = self.client.lookup(token_len, request.block_hashes)
+        num_external_hit_tokens = self.client.lookup(
+            token_len,
+            request.block_hashes,
+            self.kv_cache_group_ids,
+        )
 
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
@@ -107,6 +256,16 @@ class KVPoolScheduler:
             kvpool_cached_tokens=num_external_hit_tokens,
             can_load=False,
         )
+        logger.info(
+            "KV pool load spec created req=%s vllm_cached=%d kvpool_cached=%d "
+            "need_to_allocate=%d load_async=%s use_layerwise=%s",
+            request.request_id,
+            num_computed_tokens,
+            num_external_hit_tokens,
+            need_to_allocate,
+            self.load_async,
+            self.use_layerwise,
+        )
 
         return need_to_allocate, self.load_async and not self.use_layerwise
 
@@ -117,19 +276,32 @@ class KVPoolScheduler:
         For SharedStorageConnector, update _request_needs_load
         if the CacheManager this allocated blocks for us.
         """
-        local_block_ids = []
+        local_block_ids: list[list[int]] = [[] for _ in self.kv_cache_group_ids]
         if num_external_tokens > 0:
-            local_block_ids = blocks.get_block_ids()[0]
+            local_block_ids = normalize_block_ids_by_group(blocks.get_block_ids())
 
         self._unfinished_requests[request.request_id] = (request, local_block_ids)
         self._unfinished_request_ids.add(request.request_id)
         if request.request_id not in self.load_specs:
             # No KV tokens from external KV cache, return
+            logger.info(
+                "KV pool update_state_after_alloc req=%s has no load spec; "
+                "num_external_tokens=%d",
+                request.request_id,
+                num_external_tokens,
+            )
             return
 
         if num_external_tokens == 0:
             # No need to load anything
             self.load_specs[request.request_id].can_load = False
+            logger.info(
+                "KV pool load spec disabled req=%s because num_external_tokens=0 "
+                "vllm_cached=%d kvpool_cached=%d",
+                request.request_id,
+                self.load_specs[request.request_id].vllm_cached_tokens,
+                self.load_specs[request.request_id].kvpool_cached_tokens,
+            )
             return
 
         assert (
@@ -145,6 +317,15 @@ class KVPoolScheduler:
         )
 
         self.load_specs[request.request_id].can_load = True
+        logger.info(
+            "KV pool load spec enabled req=%s num_external_tokens=%d "
+            "vllm_cached=%d kvpool_cached=%d groups=%s",
+            request.request_id,
+            num_external_tokens,
+            self.load_specs[request.request_id].vllm_cached_tokens,
+            self.load_specs[request.request_id].kvpool_cached_tokens,
+            [len(blocks) for blocks in local_block_ids],
+        )
 
     def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:
         """Attach the connector metadata to the request object.
@@ -152,9 +333,6 @@ class KVPoolScheduler:
         This function should NOT modify other fields in the scheduler_output
         except the `kv_connector_metadata` field.
         Also, calling this function will reset the state of the connector.
-
-        Args:
-            scheduler_output (SchedulerOutput): the scheduler output object.
         """
 
         force_skip_save = self.kv_role == "kv_consumer" and not self.consumer_is_to_put
@@ -175,36 +353,45 @@ class KVPoolScheduler:
         for request in scheduler_output.scheduled_new_reqs:
             # Right now, we only load KV for new requests
             load_spec = self.load_specs.pop(request.req_id, None)
+            if load_spec is not None:
+                logger.info(
+                    "KV pool build meta attaches load spec req=%s can_load=%s "
+                    "vllm_cached=%d kvpool_cached=%d scheduled_tokens=%d "
+                    "num_computed=%d",
+                    request.req_id,
+                    load_spec.can_load,
+                    load_spec.vllm_cached_tokens,
+                    load_spec.kvpool_cached_tokens,
+                    scheduler_output.num_scheduled_tokens[request.req_id],
+                    request.num_computed_tokens,
+                )
             num_tokens_to_compute = request.num_computed_tokens + scheduler_output.num_scheduled_tokens[request.req_id]
             request_tuple = self._unfinished_requests.get(request.req_id)
             request_real = request_tuple[0]  # type: ignore[index]
-            if not isinstance(request.block_ids[0], list):
-                unfolded_block_ids = request.block_ids.copy()
-            else:
-                unfolded_block_ids = request.block_ids[0].copy()
             request_tracker = RequestTracker(
                 req_id=request.req_id,
                 token_len=num_tokens_to_compute,
-                allocated_block_ids=unfolded_block_ids,
+                allocated_block_ids_by_group=normalize_block_ids_by_group(request.block_ids),
                 num_saved_tokens=0,
                 token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
             )
             self._request_trackers[request.req_id] = request_tracker
             last_chunk_tokens_num = (
-                (len(request.prompt_token_ids) // self._block_size * self._block_size)
+                self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
                 if self._discard_partial_chunks
                 else len(request.prompt_token_ids)
             )
 
             req_meta = ReqMeta.from_request_tracker(
                 request_tracker,
-                self._block_size,
+                self.cache_transfer_granularity,
                 load_spec=load_spec,
                 skip_save=force_skip_save,
                 block_hashes=request_real.block_hashes,
                 is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
                 discard_partial_chunks=self._discard_partial_chunks,
                 original_block_size=self.original_block_size,
+                kv_cache_group_families=self.kv_cache_group_families,
             )
             if req_meta is not None:
                 meta.add_request(req_meta)
@@ -217,10 +404,6 @@ class KVPoolScheduler:
                 if not new_block_ids:
                     continue
                 if req_id in self._preempted_req_ids:
-                    if isinstance(new_block_ids, tuple):
-                        new_block_ids = new_block_ids[0].copy()
-                    else:
-                        new_block_ids = new_block_ids.copy()
                     self._preempted_req_ids.discard(req_id)
                     load_spec = self.load_specs.pop(req_id, None)
                     request_tuple = self._unfinished_requests.get(req_id)
@@ -231,25 +414,26 @@ class KVPoolScheduler:
                     request_tracker = RequestTracker(
                         req_id=req_id,
                         token_len=num_tokens_to_compute,
-                        allocated_block_ids=new_block_ids,
+                        allocated_block_ids_by_group=normalize_block_ids_by_group(new_block_ids),
                         num_saved_tokens=0,
                         token_ids=request_real.prompt_token_ids[:num_tokens_to_compute].copy(),
                     )
                     self._request_trackers[req_id] = request_tracker
                     last_chunk_tokens_num = (
-                        (len(request_real.prompt_token_ids) // self._block_size * self._block_size)
+                        self._floor_to_cache_transfer_granularity(len(request_real.prompt_token_ids))
                         if self._discard_partial_chunks
                         else len(request_real.prompt_token_ids)
                     )
                     req_meta = ReqMeta.from_request_tracker(
                         request_tracker,
-                        self._block_size,
+                        self.cache_transfer_granularity,
                         load_spec=load_spec,
                         skip_save=force_skip_save,
                         block_hashes=request_real.block_hashes,
                         is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
                         discard_partial_chunks=self._discard_partial_chunks,
                         original_block_size=self.original_block_size,
+                        kv_cache_group_families=self.kv_cache_group_families,
                     )
 
                 # decode/chunked request
@@ -272,19 +456,20 @@ class KVPoolScheduler:
                     request_tracker.update(new_block_ids)
 
                     last_chunk_tokens_num = (
-                        (len(request.prompt_token_ids) // self._block_size * self._block_size)
+                        self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
                         if self._discard_partial_chunks
                         else len(request.prompt_token_ids)
                     )
                     req_meta = ReqMeta.from_request_tracker(
                         request_tracker,
-                        self._block_size,
+                        self.cache_transfer_granularity,
                         load_spec=None,
                         skip_save=force_skip_save,
                         block_hashes=request.block_hashes,
                         is_last_chunk=request_tracker.token_len >= last_chunk_tokens_num,
                         discard_partial_chunks=self._discard_partial_chunks,
                         original_block_size=self.original_block_size,
+                        kv_cache_group_families=self.kv_cache_group_families,
                     )
                 if req_meta is not None:
                     meta.add_request(req_meta)
@@ -296,25 +481,26 @@ class KVPoolScheduler:
                 if not load_spec:
                     continue
                 num_tokens_to_compute = load_spec.kvpool_cached_tokens
-                if (num_tokens_to_compute % self._block_size != 0) and (
+                if (num_tokens_to_compute % self.cache_transfer_granularity != 0) and (
                     num_tokens_to_compute == len(request.prompt_token_ids) - 1
                 ):
                     num_tokens_to_compute = num_tokens_to_compute + 1
                 request_tracker = RequestTracker(
                     req_id=request_id,
                     token_len=num_tokens_to_compute,
-                    allocated_block_ids=block_ids,
+                    allocated_block_ids_by_group=block_ids,
                     num_saved_tokens=0,
                 )
 
                 self._request_trackers[request_id] = request_tracker
                 req_meta = ReqMeta.from_request_tracker(
                     request_tracker,
-                    self._block_size,
+                    self.cache_transfer_granularity,
                     load_spec=load_spec,
                     skip_save=None,
                     block_hashes=request.block_hashes,
                     discard_partial_chunks=self._discard_partial_chunks,
+                    kv_cache_group_families=self.kv_cache_group_families,
                 )
                 if req_meta is not None:
                     meta.add_request(req_meta)
@@ -336,7 +522,30 @@ class KVPoolScheduler:
             return False, None
         delay_free_blocks = len(block_ids) > 0
         if delay_free_blocks:
-            logger.debug("Delaying free of %d blocks for request %s", len(block_ids), request.request_id)
+            if logger.isEnabledFor(10):
+                logger.debug("Delaying free of %d blocks for request %s", len(block_ids), request.request_id)
+        return delay_free_blocks, None
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """HMA path for hybrid KV cache groups."""
+        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+            return False, None
+        tracker = self._request_trackers.get(request.request_id)
+        if tracker is not None and tracker.num_saved_tokens <= 0:
+            return False, None
+        block_ids = self.get_sw_clipped_blocks(block_ids)
+        valid_group_block_ids = [group_block_ids for group_block_ids in block_ids if group_block_ids]
+        delay_free_blocks = bool(valid_group_block_ids)
+        if delay_free_blocks:
+            logger.debug(
+                "Delaying free of %d KV cache groups for request %s",
+                len(valid_group_block_ids),
+                request.request_id,
+            )
         return delay_free_blocks, None
 
 
@@ -352,11 +561,18 @@ class LookupKeyClient:
             bind=False,
         )
 
-    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
+    def lookup(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        kv_cache_group_ids: list[int] | None = None,
+    ) -> int:
+        kv_cache_group_ids = kv_cache_group_ids or [0]
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
+        kv_group_frames = self.encoder.encode(kv_cache_group_ids)
         token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [token_len_bytes] + list(hash_frames)
+        all_frames = [token_len_bytes] + list(kv_group_frames) + list(hash_frames)
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import math
 import threading
@@ -15,6 +17,12 @@ from vllm.distributed import (
 from vllm.distributed.kv_events import BlockStored
 from vllm.logger import logger
 from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
@@ -22,6 +30,8 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     KeyMetadata,
     LayerMultiBlockReqMeta,
     ReqMeta,
+    get_cache_family_granularity,
+    infer_group_cache_families,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
     KVCacheStoreLayerRecvingThread,
@@ -50,9 +60,18 @@ class KVPoolWorker:
         self,
         vllm_config: VllmConfig,
         use_layerwize: bool,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
+        self.kv_cache_config = kv_cache_config
+        hf_text_config = getattr(model_config, "hf_text_config", None)
+        hf_config = getattr(model_config, "hf_config", hf_text_config)
+        self.hf_config = hf_text_config or hf_config
+        self.compress_ratios = getattr(hf_text_config, "compress_ratios", None)
+        if self.compress_ratios is None:
+            self.compress_ratios = getattr(hf_config, "compress_ratios", None)
+        self.use_compress = self.compress_ratios is not None
         self.dp_rank = parallel_config.data_parallel_rank
         self.use_mla = False
         if hasattr(model_config, "use_mla") and isinstance(model_config.use_mla, bool) and model_config.use_mla:
@@ -75,13 +94,27 @@ class KVPoolWorker:
             "consumer_is_to_put", False
         )
         self.backend = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
-        self.original_block_size = vllm_config.cache_config.block_size
-        self.block_size = vllm_config.cache_config.block_size
+        self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
+        self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
+        cp_scale = self.pcp_size * self.dcp_size
+        self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
+        requested_hash_block_size = vllm_config.cache_config.hash_block_size
+        self.hash_block_size = (
+            requested_hash_block_size
+            if requested_hash_block_size is not None
+            else min(self.original_block_size)
+        ) * cp_scale
+        for group_block_size in self.grouped_block_size:
+            assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
+        self.block_size = self.grouped_block_size[0]
+        self.lcm_block_size = math.lcm(*self.grouped_block_size)
+        self.num_kv_cache_groups = len(self.grouped_block_size)
+        self.kv_cache_group_families = self._infer_group_families()
+        self.group_uses_align_state = self._infer_group_uses_align_state()
+        self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
+        if self.use_layerwise and self.num_kv_cache_groups > 1:
+            raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
 
-        if self.pcp_size > 1:
-            self.block_size *= self.pcp_size
-        if self.dcp_size > 1:
-            self.block_size *= self.dcp_size
         self.current_layer = 0
         self.num_layers = model_config.get_num_layers(parallel_config)
 
@@ -130,7 +163,13 @@ class KVPoolWorker:
                     for i in range(2, remaining_layers + 2):
                         partitions[-i] += 1
 
-        self.token_database = ChunkedTokenDatabase(self.metadata, self.block_size, partitions)
+        self.token_database = ChunkedTokenDatabase(
+            self.metadata,
+            self.grouped_block_size,
+            partitions,
+            use_hybrid=self.use_hybrid,
+            hash_block_size=self.hash_block_size,
+        )
 
         backend = backend_map.get(self.backend.lower())
         assert backend is not None
@@ -153,24 +192,122 @@ class KVPoolWorker:
 
         self.finished_store_req: set[str] = set()
 
+    def _infer_group_families(self) -> list[str]:
+        kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
+        return infer_group_cache_families(kv_cache_groups, self.compress_ratios, self.hf_config)
+
+    def _infer_group_block_sizes(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig | None,
+    ) -> list[int]:
+        if kv_cache_config is None or not self.use_hybrid:
+            return [vllm_config.cache_config.block_size]
+
+        block_sizes: list[int] = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            kv_cache_spec = kv_cache_group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+            block_sizes.append(kv_cache_spec.block_size)
+        return block_sizes
+
+    def _infer_group_uses_align_state(self) -> list[bool]:
+        if self.kv_cache_config is None:
+            return [False]
+
+        group_uses_align_state: list[bool] = []
+        for group in self.kv_cache_config.kv_cache_groups:
+            kv_cache_spec = group.kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                specs = [
+                    kv_cache_spec.kv_cache_specs[layer_name]
+                    for layer_name in group.layer_names
+                ]
+            else:
+                specs = [kv_cache_spec]
+            group_uses_align_state.append(
+                any(
+                    isinstance(spec, MambaSpec)
+                    and getattr(spec, "mamba_cache_mode", None) == "align"
+                    for spec in specs
+                )
+            )
+        return group_uses_align_state
+
+    def _get_group_block_size(self, group_id: int) -> int:
+        if group_id >= len(self.grouped_block_size):
+            return self.grouped_block_size[0]
+        return self.grouped_block_size[group_id]
+
+    @staticmethod
+    def _get_group_family(families: list[str], group_id: int) -> str:
+        if group_id >= len(families):
+            return "default"
+        return families[group_id]
+
+    def _infer_cache_transfer_granularity(self) -> int:
+        granularities = [self.lcm_block_size]
+        for group_id in range(self.num_kv_cache_groups):
+            granularities.append(
+                get_cache_family_granularity(
+                    self._get_group_block_size(group_id),
+                    self._get_group_family(self.kv_cache_group_families, group_id),
+                )
+            )
+        return math.lcm(*granularities)
+
+    @staticmethod
+    def _uses_hybrid_kv_cache(vllm_config: VllmConfig, kv_cache_config: KVCacheConfig | None) -> bool:
+        if kv_cache_config is None:
+            return False
+        if getattr(vllm_config.scheduler_config, "disable_hybrid_kv_cache_manager", False):
+            return False
+        return len(kv_cache_config.kv_cache_groups) > 1 and any(
+            not isinstance(group.kv_cache_spec, FullAttentionSpec)
+            for group in kv_cache_config.kv_cache_groups
+        )
+
+    @staticmethod
+    def _as_cache_tuple(cache_or_caches) -> tuple[torch.Tensor, ...]:
+        if isinstance(cache_or_caches, torch.Tensor):
+            return (cache_or_caches,)
+        return tuple(cache_or_caches)
+
+    def _get_cache_block_metadata(self, cache: torch.Tensor) -> tuple[int, int, int, int]:
+        tensor_num_blocks = cache.shape[0]
+        assert tensor_num_blocks % self.num_blocks == 0, (
+            "The external block size must be an integer multiple of the kernel block size."
+        )
+        block_size_scale = tensor_num_blocks // self.num_blocks
+        block_len = cache[0].numel() * cache.element_size() * block_size_scale
+        block_stride = cache.stride(0) * cache.element_size() * block_size_scale
+        region_len = (self.num_blocks - 1) * block_stride + block_len if self.num_blocks else 0
+        return block_len, block_stride, region_len, block_size_scale
+
+    @staticmethod
+    def _get_storage_key(cache: torch.Tensor) -> int:
+        try:
+            return cache.untyped_storage().data_ptr()
+        except AttributeError:
+            return cache.storage().data_ptr()
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         _, first_kv_cache_tuple = next(iter(kv_caches.items()))
+        first_kv_cache_tuple = self._as_cache_tuple(first_kv_cache_tuple)
         first_kv_cache = first_kv_cache_tuple[0]
 
-        self.num_blocks = first_kv_cache.shape[0]
+        self.num_blocks = (
+            self.kv_cache_config.num_blocks if self.kv_cache_config is not None else first_kv_cache.shape[0]
+        )
         logger.info("num_blocks: %s", self.num_blocks)
-        block_rank = 3
         self.block_len = []
-        if self.use_mla or self.use_sparse:
-            for i in range(len(first_kv_cache_tuple)):
-                block_shape = first_kv_cache_tuple[i].shape[-block_rank:]
-                logger.info("block_shape: %s", block_shape)
-                self.block_len.append(first_kv_cache[i].element_size() * math.prod(block_shape))
-        else:
-            # [num_block, block_size, num_head, hidden_dim]
-            block_shape = first_kv_cache.shape[-block_rank:]
-            logger.info("block_shape: %s", block_shape)
-            self.block_len = [first_kv_cache.element_size() * math.prod(block_shape)]
+        self.block_stride = []
+        for cache in first_kv_cache_tuple:
+            block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+            logger.info("block_shape: %s", cache.shape[1:])
+            self.block_len.append(block_len)
+            self.block_stride.append(block_stride)
 
         logger.info(
             "Registering KV_Caches. use_mla: %s, use_sparse: %s, shape %s",
@@ -181,21 +318,66 @@ class KVPoolWorker:
 
         self.kv_caches = kv_caches
         self.kv_caches_base_addr = []
-        ptrs = []
-        lengths = []
-        length = len(self.block_len)
+        self.group_kv_caches_base_addr: dict[int, list[int]] = {}
+        self.group_block_len: dict[int, list[int]] = {}
+        self.group_block_stride: dict[int, list[int]] = {}
+        self.group_kv_cache_families: dict[int, str] = {
+            group_id: self._get_group_family(self.kv_cache_group_families, group_id)
+            for group_id in range(self.num_kv_cache_groups)
+        }
+        self.group_num_layers: dict[int, int] = {}
+        registered_regions: dict[int, tuple[int, int]] = {}
         for cache_or_caches in kv_caches.values():
-            # Normalize to always be a list of caches
-            for i, cache in enumerate(cache_or_caches, 0):
+            for cache in self._as_cache_tuple(cache_or_caches):
                 base_addr = cache.data_ptr()
-                region_len = self.num_blocks * self.block_len[i % length]
+                _, _, region_len, _ = self._get_cache_block_metadata(cache)
                 self.kv_caches_base_addr.append(base_addr)
-                ptrs.append(base_addr)
-                lengths.append(region_len)
+                storage_key = self._get_storage_key(cache)
+                start = base_addr
+                end = base_addr + region_len
+                if storage_key in registered_regions:
+                    old_start, old_end = registered_regions[storage_key]
+                    registered_regions[storage_key] = (min(old_start, start), max(old_end, end))
+                else:
+                    registered_regions[storage_key] = (start, end)
+
+        ptrs = [start for start, _ in registered_regions.values()]
+        lengths = [end - start for start, end in registered_regions.values()]
+
+        if self.kv_cache_config is not None and self.use_hybrid:
+            for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
+                group_addrs: list[int] = []
+                group_block_lens: list[int] = []
+                group_block_strides: list[int] = []
+                seen_group_ptrs: set[int] = set()
+                for layer_name in group_spec.layer_names:
+                    cache_or_caches = kv_caches[layer_name]
+                    for cache in self._as_cache_tuple(cache_or_caches):
+                        base_addr = cache.data_ptr()
+                        if base_addr in seen_group_ptrs:
+                            continue
+                        block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+                        group_addrs.append(base_addr)
+                        group_block_lens.append(block_len)
+                        group_block_strides.append(block_stride)
+                        seen_group_ptrs.add(base_addr)
+                self.group_kv_caches_base_addr[group_id] = group_addrs
+                self.group_block_len[group_id] = group_block_lens
+                self.group_block_stride[group_id] = group_block_strides
+                self.group_num_layers[group_id] = len(group_spec.layer_names)
 
         self.m_store.register_buffer(ptrs, lengths)
         self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)
         self.token_database.set_block_len(self.block_len)
+        self.token_database.set_block_stride(self.block_stride)
+        self.token_database.set_group_buffers(
+            self.group_kv_caches_base_addr,
+            self.group_block_len,
+            self.group_block_stride,
+            cache_role="kv",
+            group_cache_families=self.group_kv_cache_families,
+            group_num_layers=self.group_num_layers,
+        )
 
         if self.use_layerwise:
             self.get_event = threading.Event()
@@ -251,18 +433,37 @@ class KVPoolWorker:
     def start_load_kv(self, metadata: AscendConnectorMetadata):
         self.current_layer = 0
         self.layerwise_retrievers = []
+        logger.info("KV pool worker start_load_kv requests=%d", len(metadata.requests))
         for request in metadata.requests:
             load_spec = request.load_spec
             if load_spec is None or not load_spec.can_load:  # load =0
+                logger.info(
+                    "KV pool worker skip get req=%s reason=%s",
+                    request.req_id,
+                    "no_load_spec" if load_spec is None else f"can_load={load_spec.can_load}",
+                )
                 continue
+            request.skip_null_blocks_by_group = self.group_uses_align_state
+            load_group_ids = request.kv_cache_group_ids or [0]
             token_len = request.token_len_chunk
-            if (load_spec.kvpool_cached_tokens % self.block_size != 0) and (
+            if (load_spec.kvpool_cached_tokens % self.cache_transfer_granularity != 0) and (
                 load_spec.kvpool_cached_tokens == token_len - 1
             ):
                 token_len = request.load_spec.kvpool_cached_tokens + 1
             else:
                 token_len = request.load_spec.kvpool_cached_tokens
             request.load_spec.token_len = token_len
+            logger.info(
+                "KV pool worker prepare get req=%s token_len_chunk=%d get_token_len=%d "
+                "vllm_cached=%d kvpool_cached=%d groups=%s load_async=%s",
+                request.req_id,
+                request.token_len_chunk,
+                token_len,
+                load_spec.vllm_cached_tokens,
+                load_spec.kvpool_cached_tokens,
+                load_group_ids,
+                self.load_async,
+            )
             if self.use_layerwise:
                 layerwise_retriever = self.retrieve_layer(request)
                 next(layerwise_retriever)  # first layer load
@@ -276,14 +477,33 @@ class KVPoolWorker:
                     addr_list = []
                     size_list = []
                     key_list = []
-                    mask_num = request.load_spec.vllm_cached_tokens // self.block_size * self.block_size
-                    for start, end, key in self.token_database.process_tokens(
-                        token_len, request.block_hashes, mask_num
-                    ):
-                        addr, size, _ = self.token_database.prepare_value(start, end, request.block_ids)
-                        key_list.append(key.to_string())
-                        addr_list.append(addr)
-                        size_list.append(size)
+                    for group_id in load_group_ids:
+                        block_ids = request.block_ids_by_group[group_id]
+                        group_block_size = self.grouped_block_size[group_id]
+                        mask_num = request.load_spec.vllm_cached_tokens // group_block_size * group_block_size
+                        skip_null = (
+                            group_id < len(self.group_uses_align_state)
+                            and self.group_uses_align_state[group_id]
+                        )
+                        for start, end, key, _ in self.token_database.process_tokens_with_block_ids(
+                            token_len,
+                            request.block_hashes,
+                            block_ids,
+                            mask_num,
+                            kv_cache_group_id=group_id,
+                            skip_null_blocks=skip_null,
+                        ):
+                            addr, size, _ = self.token_database.prepare_value(
+                                start,
+                                end,
+                                block_ids,
+                                kv_cache_group_id=group_id,
+                            )
+                            key_list.append(key.to_string())
+                            addr_list.append(addr)
+                            size_list.append(size)
+                    if not key_list:
+                        continue
                     key_list_c = key_list[self.tp_rank % len(key_list) :] + key_list[: self.tp_rank % len(key_list)]
                     addr_list_c = (
                         addr_list[self.tp_rank % len(addr_list) :] + addr_list[: self.tp_rank % len(addr_list)]
@@ -291,7 +511,23 @@ class KVPoolWorker:
                     size_list_c = (
                         size_list[self.tp_rank % len(size_list) :] + size_list[: self.tp_rank % len(size_list)]
                     )
+                    logger.info(
+                        "KV pool worker calls backend get request=%s token_len=%d groups=%s "
+                        "keys=%d sample_keys=%s",
+                        request.req_id,
+                        token_len,
+                        load_group_ids,
+                        len(key_list_c),
+                        key_list_c[:3],
+                    )
                     self.m_store.get(key_list_c, addr_list_c, size_list_c)
+                    logger.info(
+                        "KV pool worker backend get returned request=%s token_len=%d groups=%s keys=%d",
+                        request.req_id,
+                        token_len,
+                        load_group_ids,
+                        len(key_list_c),
+                    )
 
     def wait_for_layer_load(self) -> None:
         for layerwise_retriever in self.layerwise_retrievers:
@@ -328,6 +564,7 @@ class KVPoolWorker:
 
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
         current_event = None
+        has_save_request = False
         for request in connector_metadata.requests:
             can_save = request.can_save
             if can_save is None or not can_save:
@@ -341,6 +578,8 @@ class KVPoolWorker:
             if can_save is None or not can_save:
                 continue
 
+            request.skip_null_blocks_by_group = self.group_uses_align_state
+            request.disable_tp_key_sharding = (self.use_mla or self.use_sparse) and self.put_step > 1
             request.current_event = current_event
             self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
                 request.req_id
@@ -348,6 +587,13 @@ class KVPoolWorker:
             self.kv_send_thread.add_request(  # type: ignore[union-attr]
                 request,
             )
+            has_save_request = True
+
+        if has_save_request:
+            # vLLM expects wait_for_save() to make stores visible before the
+            # request is reported as finished. Without this barrier a following
+            # identical prompt can lookup before Mooncake put() has completed.
+            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
 
     def retrieve_layer(
         self,
@@ -400,7 +646,7 @@ class KVPoolWorker:
                         logger.info("Layerwise get failed")
                 self.get_event.clear()
                 req_meta = LayerMultiBlockReqMeta(
-                    request.req_id, keys_multi_chunk, starts, ends, request.block_ids, layer_id
+                    request.req_id, keys_multi_chunk, starts, ends, request.block_ids_by_group, layer_id
                 )
                 self.kv_recv_thread.add_request(  # type: ignore[union-attr, call-arg]
                     req_meta
@@ -460,7 +706,7 @@ class KVPoolWorker:
                     keys_multi_chunk,
                     starts,
                     ends,
-                    request.block_ids,
+                    request.block_ids_by_group,
                     layer_id,
                     request.is_last_chunk,
                     current_event,
@@ -537,96 +783,231 @@ class KVPoolWorker:
         self,
         token_len: int,
         block_hashes: list[BlockHash],
-        use_layerwise: bool,
+        kv_cache_group_ids: list[int] | None = None,
+        use_layerwise: bool = False,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
         :param tokens: the input tokens, with shape [seq_len]
         :return: An int indicating how many prefix tokens are cached.
         """
-        end = 0
-        keys = []
         try:
-            starts = []
-            for start, end, key in self.token_database.process_tokens(token_len, block_hashes):
+            hits = []
+            kv_cache_group_ids = kv_cache_group_ids or [0]
+            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
+            for group_id in kv_cache_group_ids:
+                end = 0
+                keys = []
+                starts = []
+                ends = []
+                for start, end, key in self.token_database.process_tokens(
+                    token_len,
+                    block_hashes,
+                    kv_cache_group_id=group_id,
+                ):
+                    if use_layerwise:
+                        keys_multi_layer = key.split_layers(self.num_layers)
+                        for item in keys_multi_layer:
+                            keys.append(item.to_string())
+                    else:
+                        keys.append(key.to_string())
+                    starts.append(start)
+                    ends.append(end)
+
+                if not keys:
+                    hits.append(0)
+                    continue
+
+                res = self.m_store.exists(keys)  # type: ignore[assignment]
+
                 if use_layerwise:
-                    keys_multi_layer = key.split_layers(self.num_layers)
-                    for item in keys_multi_layer:
-                        keys.append(item.to_string())
+                    res = self.check_all_layers_exists(res, self.num_layers)
+                if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
+                    hit_end = 0
+                    for index in range(len(ends) - 1, -1, -1):
+                        if (
+                            res[index] == 1  # type: ignore[index]
+                            and ends[index] % self.cache_transfer_granularity == 0
+                        ):
+                            hit_end = ends[index]
+                            break
                 else:
-                    keys.append(key.to_string())
-                starts.append(start)
-
-            res = self.m_store.exists(keys)  # type: ignore[assignment]
-
-            if use_layerwise:
-                res = self.check_all_layers_exists(res, self.num_layers)
-            for index, value in enumerate(res):  # type: ignore[arg-type]
-                if value != 1:
-                    return starts[index]
-            # all tokens where found, return the maximal end
+                    hit_end = end
+                    for index, value in enumerate(res):  # type: ignore[arg-type]
+                        if value != 1:
+                            hit_end = 0
+                            for hit_index in range(index, 0, -1):
+                                if starts[hit_index] % self.cache_transfer_granularity == 0:
+                                    hit_end = starts[hit_index]
+                                    break
+                            break
+                hits.append(hit_end)
         except Exception as e:
-            logger.error(f"Remote connection failed in contains: {e}")
+            logger.error("Remote connection failed in contains: %s", e)
             return 0
-        return end
+        return min(hits) if hits else 0
+
+    def _get_lookup_gate_group_ids(self, kv_cache_group_ids: list[int]) -> list[int]:
+        gate_group_ids = [
+            group_id
+            for group_id in kv_cache_group_ids
+            if self._is_lookup_gate_group(group_id)
+        ]
+        if not gate_group_ids:
+            return kv_cache_group_ids
+        if len(gate_group_ids) != len(kv_cache_group_ids):
+            logger.info(
+                "KV pool lookup gates on groups %s, ignoring non-gate groups from %s",
+                gate_group_ids,
+                kv_cache_group_ids,
+            )
+        return gate_group_ids
+
+    def _is_lookup_gate_group(self, group_id: int) -> bool:
+        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
+            return False
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        # DeepSeek V4 has a c128 compressed KV group. Its key stream is much
+        # sparser than the dense KV groups, so using it as a strict gate makes
+        # the whole request report 0 hit even when the loadable groups exist.
+        if cache_family == "c128":
+            return False
+        # The DSV4 c4 group is currently written as a TP-sharded key stream in
+        # this connector path. Runtime logs show only 32/128 keys visible for a
+        # 16K prompt, so letting it gate the external pool prevents otherwise
+        # complete c1 groups from loading. Keep pooling gate/load on complete
+        # 128-token c1 KV groups until c4 storage is made fully discoverable.
+        if cache_family != "c1":
+            return False
+        # In the DSV4 hybrid layout, some auxiliary groups use smaller logical
+        # block sizes (for example 8/32). The Ascend kernels in this path are
+        # fixed to the 128-token KV block shape, so those groups cannot be used
+        # as external-pool gates or load targets for the 16K pooling path.
+        return self._get_group_block_size(group_id) == self.block_size
+
+    def _get_group_num_kv_heads(self, group_id: int) -> int:
+        if self.use_mla or self.use_sparse:
+            return 1
+        if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
+            return 1
+        return self.num_kv_head
 
     def lookup_scheduler(
         self,
         token_len: int,
         block_hashes: list[BlockHash],
-        use_layerwise: bool,
+        kv_cache_group_ids: list[int] | None = None,
+        use_layerwise: bool = False,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
         :param tokens: the input tokens, with shape [seq_len]
         :return: An int indicating how many prefix tokens are cached.
         """
-        end = 0
-        keys = []
         try:
-            starts = []
-            for start, end, key in self.token_database.process_tokens(token_len, block_hashes):
+            hits = []
+            kv_cache_group_ids = kv_cache_group_ids or [0]
+            kv_cache_group_ids = self._get_lookup_gate_group_ids(kv_cache_group_ids)
+            for group_id in kv_cache_group_ids:
+                end = 0
+                keys = []
+                starts = []
+                ends = []
+                for start, end, key in self.token_database.process_tokens(
+                    token_len,
+                    block_hashes,
+                    kv_cache_group_id=group_id,
+                ):
+                    if use_layerwise:
+                        keys_multi_layer = key.split_layers(self.num_layers)
+                        for item in keys_multi_layer:
+                            keys.append(item.to_string())
+                    else:
+                        keys.append(key.to_string())
+                    starts.append(start)
+                    ends.append(end)
+
+                if not keys:
+                    hits.append(0)
+                    continue
+
+                multi_tp_keys = keys[:]
+                group_tp_size = min(self.tp_size, self._get_group_num_kv_heads(group_id))
+                for i in range(1, group_tp_size):
+                    for item in keys:
+                        new_str = item.replace(  # type: ignore[attr-defined]
+                            "@head_or_tp_rank:0", f"@head_or_tp_rank:{i}", 1
+                        )
+                        multi_tp_keys.append(new_str)
+
+                pp_base_keys = multi_tp_keys.copy()
+                for i in range(1, self.pp_size):
+                    for item in pp_base_keys:
+                        new_str = item.replace(  # type: ignore[attr-defined]
+                            "@pp_rank:0", f"@pp_rank:{i}", 1
+                        )
+                        multi_tp_keys.append(new_str)
+
+                res = self.m_store.exists(multi_tp_keys)  # type: ignore[assignment]
+                num_block = len(keys)
                 if use_layerwise:
-                    keys_multi_layer = key.split_layers(self.num_layers)
-                    for item in keys_multi_layer:
-                        keys.append(item.to_string())
+                    res = self.check_all_layers_exists(res, self.num_layers)
+                    num_block = len(keys) // self.num_layers
+                multi_tp_values = [
+                    res[i * num_block : (i + 1) * num_block]  # type: ignore[index]
+                    for i in range(group_tp_size * self.pp_size)
+                ]
+                first_missing = self.find_min_first_non_one_index(multi_tp_values)
+                logger.info(
+                    "KV pool lookup request token_len=%d group=%d keys=%d multi_tp_keys=%d "
+                    "exists_count=%d/%d first_missing=%d exists_sample=%s sample_keys=%s",
+                    token_len,
+                    group_id,
+                    len(keys),
+                    len(multi_tp_keys),
+                    sum(1 for value in res if value == 1),  # type: ignore[union-attr]
+                    len(res),
+                    first_missing,
+                    list(res[: min(12, len(res))]),  # type: ignore[index]
+                    multi_tp_keys[:3],
+                )
+                if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
+                    exists_by_block = [all(values[idx] == 1 for values in multi_tp_values) for idx in range(num_block)]
+                    hit_end = 0
+                    for index in range(num_block - 1, -1, -1):
+                        if exists_by_block[index] and ends[index] % self.cache_transfer_granularity == 0:
+                            hit_end = ends[index]
+                            break
+                    hits.append(hit_end)
                 else:
-                    keys.append(key.to_string())
-                starts.append(start)
-
-            multi_tp_keys = keys[:]
-            for i in range(1, min(self.tp_size, self.num_kv_head)):
-                for item in keys:
-                    new_str = item.replace(  # type: ignore[attr-defined]
-                        "@head_or_tp_rank:0", f"@head_or_tp_rank:{i}", 1
-                    )
-                    multi_tp_keys.append(new_str)
-
-            pp_base_keys = multi_tp_keys.copy()
-            for i in range(1, self.pp_size):
-                for item in pp_base_keys:
-                    new_str = item.replace(  # type: ignore[attr-defined]
-                        "@pp_rank:0", f"@pp_rank:{i}", 1
-                    )
-                    multi_tp_keys.append(new_str)
-
-            res = self.m_store.exists(multi_tp_keys)  # type: ignore[assignment]
-            num_block = len(keys)
-            if use_layerwise:
-                res = self.check_all_layers_exists(res, self.num_layers)
-                num_block = len(keys) // self.num_layers
-            multi_tp_values = [
-                res[i * num_block : (i + 1) * num_block]  # type: ignore[index]
-                for i in range(min(self.tp_size, self.num_kv_head) * self.pp_size)
-            ]
-            index = self.find_min_first_non_one_index(multi_tp_values)
-            if index != -1:
-                return starts[index]
-        # all tokens where found, return the maximal end
+                    index = first_missing
+                    if index == -1:
+                        hits.append(end)
+                    else:
+                        hit_end = 0
+                        for hit_index in range(index, 0, -1):
+                            if starts[hit_index] % self.cache_transfer_granularity == 0:
+                                hit_end = starts[hit_index]
+                                break
+                        hits.append(hit_end)
+                logger.info(
+                    "KV pool scheduler lookup group=%d keys=%d hit=%d token_len=%d",
+                    group_id,
+                    len(keys),
+                    hits[-1],
+                    token_len,
+                )
         except Exception as e:
-            logger.error(f"Remote connection failed in contains: {e}")
+            logger.error("Remote connection failed in contains: %s", e)
             return 0
-        return end
+        logger.info(
+            "KV pool scheduler lookup final token_len=%d groups=%s hits=%s result=%d",
+            token_len,
+            kv_cache_group_ids,
+            hits,
+            min(hits) if hits else 0,
+        )
+        return min(hits) if hits else 0
 
     def check_all_layers_exists(self, res: list[int], num_layers: int) -> list[int]:
         total_chunks = len(res) // num_layers


### PR DESCRIPTION
- Support multiple KV cache groups with different block sizes
- Add group-aware block management and lookup logic
- Implement group-specific cache family handling for DSV4
- Add cache transfer granularity per group
- Add comprehensive logging for KV pool operations
- Support SWA (Sliding Window Attention) block clipping

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
