### PR TITLE
micro_batch MOE multi-stream coverage function

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -86,6 +86,14 @@ class AscendConfig:
                 )
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         self.multistream_overlap_gate = additional_config.get("multistream_overlap_gate", False)
+        self.prefill_micro_batch_moe_overlap = additional_config.get("prefill_micro_batch_moe_overlap", False)
+        self.prefill_micro_batch_moe_overlap_split_ratio = additional_config.get(
+            "prefill_micro_batch_moe_overlap_split_ratio", 0.8
+        )
+        if not 0 < self.prefill_micro_batch_moe_overlap_split_ratio < 1:
+            raise ValueError(
+                "multistream_prefill_moe_overlap_split_ratio must be in the open interval (0, 1)."
+            )
         self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
         self.multistream_dsa_preprocess = additional_config.get(

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -23,6 +23,7 @@ from vllm.distributed import get_tp_group
 from vllm.forward_context import get_forward_context
 
 from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.distributed.utils import split_tensor_along_first_dim
 
 from vllm_ascend.device.device_op import DeviceOperator
@@ -252,6 +253,14 @@ def _select_experts_with_fusion_ops(
                     input_ids, num_partitions=tp_size)
                 input_ids = splitted_input[tp_rank].contiguous()
             input_ids = torch.where(input_ids == -1, 0, input_ids)
+
+            if get_ascend_config().prefill_micro_batch_moe_overlap:
+                # In microbatch mode, input_ids can be longer than router_logits
+                # because hidden_states was split before prepare/all-gather.
+                # Slice input_ids to the current token count.
+                num_tokens = router_logits.shape[0]
+                if input_ids.numel() > num_tokens:
+                    input_ids = input_ids[:num_tokens]
         else:
             input_ids = None
             tid2eid_ones = None

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -47,6 +47,7 @@ from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_NZ,
     enable_sp,
     maybe_trans_nz,
+    microbatch_overlap_stream,
     npu_stream_switch,
     shared_expert_dp_enabled,
     shared_experts_calculation_stream,
@@ -59,7 +60,6 @@ class FusedMoEResult:
     before_dispatch_evt: torch.npu.Event | None = None
     before_gmm2_evt: torch.npu.Event | None = None
     before_combine_evt: torch.npu.Event | None = None
-    swiglu_limit: int = 0
 
 
 @dataclass
@@ -68,7 +68,32 @@ class FusedMoEEvents:
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
-    swiglu_limit: int = 0
+
+
+class MicrobatchOverlapEvents:
+    """Event container shared by batch0, batch1, and shared experts."""
+
+    __slots__ = (
+        "b0_quant_done",
+        "b0_unpermute_done",
+        "b1_quant_done",
+        "b1_unpermute_done",
+    )
+
+    def __init__(self):
+        self.b0_quant_done: torch.npu.Event | None = None
+        self.b0_unpermute_done: torch.npu.Event | None = None
+        self.b1_quant_done: torch.npu.Event | None = None
+        self.b1_unpermute_done: torch.npu.Event | None = None
+
+    def to_shared_expert_events(self) -> FusedMoEEvents:
+        """Map batch1 events to the shared-expert synchronization interface."""
+        return FusedMoEEvents(
+            before_routed_experts=self.b1_quant_done,
+            before_dispatch=self.b1_quant_done,
+            before_gmm2=self.b1_unpermute_done,
+            before_combine=self.b1_unpermute_done,
+        )
 
 
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
@@ -459,7 +484,9 @@ class AscendFusedMoE(FusedMoE):
         )
 
     def forward_impl(  # type: ignore[override]
-        self, hidden_states: torch.Tensor, router_logits: torch.Tensor, return_with_event: bool = False
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor,
+        return_with_event: bool = False,
+        overlap_events=None, microbatch_role: str | None = None,
     ) -> torch.Tensor | FusedMoEResult:
         assert self.quant_method is not None
 
@@ -526,6 +553,8 @@ class AscendFusedMoE(FusedMoE):
             replace_allreduce=_EXTRA_CTX.flash_comm_v1_enabled,
             enable_shared_expert_dp=self.enable_shared_expert_dp,
             quant_type=self.quant_type,
+            overlap_events=overlap_events,
+            microbatch_role=microbatch_role,
         )
         hidden_states = prepare_output.hidden_states
         router_logits = prepare_output.router_logits
@@ -536,6 +565,16 @@ class AscendFusedMoE(FusedMoE):
         # Make sure the default stream waits for the gate stream to finish.
         if self.multistream_overlap_gate:
             torch.npu.current_stream().wait_stream(AscendFusedMoE.gate_stream)
+
+        # Expose microbatch state to fused_experts() without changing apply() signatures.
+        if overlap_events is not None:
+            _EXTRA_CTX.moe_comm_method._overlap_events = overlap_events
+            _EXTRA_CTX.moe_comm_method._microbatch_role = microbatch_role
+
+        # Batch1 enters routed experts only after batch0 completes them.
+        if overlap_events is not None and microbatch_role == "batch1":
+            if overlap_events.b0_unpermute_done is not None:
+                torch.npu.current_stream().wait_event(overlap_events.b0_unpermute_done)
 
         # Matrix multiply.
         fused_experts_results: FusedExpertsResult = self.quant_method.apply(
@@ -581,10 +620,17 @@ class AscendFusedMoE(FusedMoE):
                 self.load_counter.add_(1)
             else:
                 self.moe_load.add_(local_load)
+
+        if overlap_events is not None:
+            _EXTRA_CTX.moe_comm_method._overlap_events = None
+            _EXTRA_CTX.moe_comm_method._microbatch_role = None
+
         routed_out = _EXTRA_CTX.moe_comm_method.finalize(
             hidden_states=fused_experts_results.routed_out,
             reduce_results=self.reduce_results,
             padded_hidden_states_shape=padded_hidden_states_shape,
+            overlap_events=overlap_events,
+            microbatch_role=microbatch_role,
         )
 
         if return_with_event:
@@ -593,7 +639,6 @@ class AscendFusedMoE(FusedMoE):
                 before_dispatch_evt=fused_experts_results.before_dispatch_evt,
                 before_gmm2_evt=fused_experts_results.before_gmm2_evt,
                 before_combine_evt=fused_experts_results.before_combine_evt,
-                swiglu_limit=fused_experts_results.swiglu_limit
             )
         else:
             # The vLLM FusedMoE forward_impl does not return events.
@@ -730,8 +775,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
-            # Only used for int quantization
-            if self.quant_type == QuantType.W8A8 or self.quant_type == QuantType.W4A8:
+            if self.quant_type == QuantType.W8A8:
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -748,9 +792,8 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                     output_dtype=torch.int32
                 )
                 # Execute activation concurrently with gmm2.
-
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+                quantized_x, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
                     x=hidden_states,
                     weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
                     activation_scale=pertoken_scale,
@@ -759,9 +802,7 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                     quant_offset=None,
                     group_index=None,
                     activate_left=True,
-                    quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
+                    quant_mode=1
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.
@@ -818,6 +859,12 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
         else:
             before_routed_experts = torch.npu.current_stream().record_event()
 
+        # Microbatch overlap path: split before prepare(quant+allgather)
+        if self._should_use_microbatch_overlap(hidden_states):
+            return self._forward_with_microbatch_overlap(
+                hidden_states, router_logits, before_routed_experts
+            )
+
         fused_moe_results = AscendFusedMoE.forward_impl(
             self,
             hidden_states=hidden_states,
@@ -841,8 +888,102 @@ class AscendSharedFusedMoE(SharedFusedMoE, AscendFusedMoE):
                     before_dispatch=fused_moe_results.before_dispatch_evt,
                     before_gmm2=fused_moe_results.before_gmm2_evt,
                     before_combine=fused_moe_results.before_combine_evt,
-                    swiglu_limit=fused_moe_results.swiglu_limit
                 ),
             )
 
+        return shared_out, routed_out
+
+    def _should_use_microbatch_overlap(self, hidden_states: torch.Tensor) -> bool:
+        """Check if microbatch overlap should be used."""
+        ascend_config = get_ascend_config()
+        if not ascend_config.prefill_micro_batch_moe_overlap:
+            return False
+        if not isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl):
+            return False
+        if hidden_states.shape[0] <= 1:
+            return False
+        return True
+
+    def _forward_with_microbatch_overlap(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        before_routed_experts: torch.npu.Event,
+    ):
+        """Run the Prefill MoE microbatch overlap path.
+
+        Batch0 and batch1 both call ``AscendFusedMoE.forward_impl()`` with a
+        shared event container and keep the same stage structure as the
+        baseline path. The current synchronization points are:
+          - After quant in prepare: ``b0_quant_done`` / ``b1_quant_done``
+          - After routed experts finish: ``b0_unpermute_done`` /
+            ``b1_unpermute_done``
+
+        Batch1 waits for batch0 before entering routed experts. Shared experts
+        consume batch1 events to overlap their compute with the routed path.
+        """
+        num_tokens = hidden_states.shape[0]
+        split_ratio = get_ascend_config().prefill_micro_batch_moe_overlap_split_ratio
+        mid = int(num_tokens * split_ratio)
+        mid = max(1, min(mid, num_tokens - 1))
+
+        # --- Split inputs ---
+        hidden_states_b0 = hidden_states[:mid]
+        hidden_states_b1 = hidden_states[mid:]
+        router_logits_b0 = router_logits[:mid]
+        router_logits_b1 = router_logits[mid:]
+
+        mb_stream = microbatch_overlap_stream()
+
+        # Shared event container: batch0 produces events for batch1, and
+        # batch1 produces events for shared experts.
+        overlap_events = MicrobatchOverlapEvents()
+
+        # Run the full batch0 pipeline on the main stream.
+        fused_moe_results_b0 = AscendFusedMoE.forward_impl(
+            self,
+            hidden_states=hidden_states_b0,
+            router_logits=router_logits_b0,
+            return_with_event=True,
+            overlap_events=overlap_events,
+            microbatch_role="batch0",
+        )
+        routed_out_b0 = fused_moe_results_b0.routed_out
+
+        # Run the full batch1 pipeline on the microbatch stream.
+        with npu_stream_switch(mb_stream):
+            fused_moe_results_b1 = AscendFusedMoE.forward_impl(
+                self,
+                hidden_states=hidden_states_b1,
+                router_logits=router_logits_b1,
+                return_with_event=True,
+                overlap_events=overlap_events,
+                microbatch_role="batch1",
+            )
+            routed_out_b1 = fused_moe_results_b1.routed_out
+
+        evt_b1_all_done = mb_stream.record_event()
+
+        # Defer ReduceScatter so RS-b0 does not block AG-b1, then run RS-b1
+        # only after batch1 finishes on the microbatch stream.
+        moe_comm_method = _EXTRA_CTX.moe_comm_method
+        routed_out_b0 = moe_comm_method.prepare_finalize.finalize(
+            routed_out_b0, self.reduce_results, None)
+        torch.npu.current_stream().wait_event(evt_b1_all_done)
+        routed_out_b1 = moe_comm_method.prepare_finalize.finalize(
+            routed_out_b1, self.reduce_results, None)
+
+        # Overlap shared experts with the batch1 pipeline.
+        if self._shared_experts is not None:
+            shared_out = self._forward_shared_experts(
+                hidden_states,
+                overlap_events.to_shared_expert_events(),
+            )
+        else:
+            shared_out = None
+
+        routed_out = torch.cat([routed_out_b0, routed_out_b1], dim=0)
+
+        if shared_out is None:
+            return routed_out
         return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -78,7 +78,6 @@ class FusedExpertsResult:
     # For dynamic_eplb
     group_list_type: int = 1
     expert_tokens: torch.Tensor | None = None
-    swiglu_limit: int = 0
 
 
 class MoECommMethod(ABC):
@@ -98,6 +97,8 @@ class MoECommMethod(ABC):
         enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type: QuantType = QuantType.NONE,
+        overlap_events=None,
+        microbatch_role: str | None = None,
     ) -> MoEPrepareOutput:
         return self.prepare_finalize.prepare(
             hidden_states,
@@ -105,6 +106,8 @@ class MoECommMethod(ABC):
             enable_shared_expert_dp,
             replace_allreduce,
             quant_type,
+            overlap_events,
+            microbatch_role,
         )
 
     def finalize(
@@ -112,7 +115,18 @@ class MoECommMethod(ABC):
         hidden_states: torch.Tensor,
         reduce_results: bool,
         padded_hidden_states_shape: torch.Size | None = None,
+        overlap_events=None,
+        microbatch_role: str | None = None,
     ) -> torch.Tensor:
+        if overlap_events is not None:
+            if microbatch_role == "batch0":
+                overlap_events.b0_unpermute_done = torch.npu.current_stream().record_event()
+            elif microbatch_role == "batch1":
+                overlap_events.b1_unpermute_done = torch.npu.current_stream().record_event()
+            # Skip ReduceScatter here. It is deferred to
+            # _forward_with_microbatch_overlap so RS-b0 does not block AG-b1.
+            return hidden_states
+
         hidden_states = self.prepare_finalize.finalize(hidden_states, reduce_results, padded_hidden_states_shape)
         return hidden_states
 
@@ -127,6 +141,10 @@ class MoECommMethod(ABC):
         assert moe_comm_method is not None, "Missing communication context"
 
         before_dispatch_evt = torch.npu.current_stream().record_event()
+
+        overlap_events = getattr(self, '_overlap_events', None)
+        microbatch_role = getattr(self, '_microbatch_role', None)
+
         routed_topk_ids = fused_experts_input.topk_ids
         if fused_experts_input.routing.log2phy is not None:
             routed_topk_ids = fused_experts_input.routing.log2phy[routed_topk_ids]
@@ -158,7 +176,6 @@ class MoECommMethod(ABC):
             before_combine_evt=before_combine_evt,
             group_list_type=token_dispatch_output.group_list_type,
             expert_tokens=token_dispatch_output.group_list,
-            swiglu_limit=fused_experts_input.swiglu_limit
         )
 
     def _apply_mlp(self, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
@@ -330,4 +347,4 @@ class FusedMC2CommImpl(MoECommMethod):
             )
         else:
             raise ValueError(f"Wrong value of {envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2=}")
-        return FusedExpertsResult(routed_out=out, expert_tokens=expert_tokens, swiglu_limit=fused_experts_input.swiglu_limit)
+        return FusedExpertsResult(routed_out=out, expert_tokens=expert_tokens)

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -66,6 +66,8 @@ class PrepareAndFinalize(ABC):
         enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type: QuantType = QuantType.NONE,
+        overlap_events=None,
+        microbatch_role: str | None = None,
     ) -> MoEPrepareOutput:
         """
         Prepare tensors before MoE computation. May involve:
@@ -347,6 +349,8 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
+        overlap_events=None,
+        microbatch_role: str | None = None,
     ) -> MoEPrepareOutput:
         """
         Preparation steps:
@@ -356,13 +360,18 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             MoEPrepareOutput with global tensors.
         """
         if enable_sp() or enable_sp_by_pass():
-            return self._prepare_with_ep_group(hidden_states, router_logits, quant_type)
+            return self._prepare_with_ep_group(hidden_states, router_logits, quant_type, overlap_events, microbatch_role)
 
         return self._prepare_with_dp_group(hidden_states, router_logits, enable_shared_expert_dp, replace_allreduce)
 
     def _prepare_with_ep_group(
-        self, hidden_states: torch.Tensor, router_logits: torch.Tensor, quant_type=QuantType.NONE
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor, quant_type=QuantType.NONE,
+        overlap_events=None, microbatch_role: str | None = None,
     ) -> MoEPrepareOutput:
+        if overlap_events is not None and microbatch_role == "batch1":
+            if overlap_events.b0_quant_done is not None:
+                torch.npu.current_stream().wait_event(overlap_events.b0_quant_done)
+
         pertoken_scale = None
         if quant_type == QuantType.W8A8:
             hidden_states, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
@@ -370,6 +379,12 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             # TODO(linfeng): MXFP8 with AllGather+EP currently does not pre-quantize
             # per-token activations in prepare. Keep quantization in the MoE MLP path.
             pass
+
+        if overlap_events is not None:
+            if microbatch_role == "batch0":
+                overlap_events.b0_quant_done = torch.npu.current_stream().record_event()
+            elif microbatch_role == "batch1":
+                overlap_events.b1_quant_done = torch.npu.current_stream().record_event()
 
         if self.multistream_overlap_gate:
             assert PrepareAndFinalize.quant_stream is not None

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -456,6 +456,16 @@ def attention_calculation_stream() -> torch.npu.Stream:
         _ATNN_CALCULATION_STREAM = torch_npu.npu.Stream()
     return _ATNN_CALCULATION_STREAM
 
+
+_MICROBATCH_OVERLAP_STREAM: torch.npu.Stream | None = None
+
+
+def microbatch_overlap_stream() -> torch.npu.Stream:
+    global _MICROBATCH_OVERLAP_STREAM
+    if _MICROBATCH_OVERLAP_STREAM is None:
+        _MICROBATCH_OVERLAP_STREAM = torch_npu.npu.Stream()
+    return _MICROBATCH_OVERLAP_STREAM
+
 def adapt_patch(is_global_patch: bool = False):
     if is_global_patch:
         from vllm_ascend.patch import platform  # noqa: F401


### PR DESCRIPTION
Adding microbatch MOE overlap functionality enables concurrent communication between allreduce, reducescatter, and other operations with cube and vessel execution operators, thus compressing MOE's end-to-end time.
