### PR TITLE
fix(deepseek-v4): improve MTP accuracy and acceptance

### DIFF
--- a/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
+++ b/csrc/attention/compressor/op_kernel/arch32/compressor_block_vec_perf.h
@@ -729,6 +729,33 @@ __aicore__ inline void CompressorBlockVectorPerf<COMP>::SaveState(const LocalTen
 {
     if constexpr (COMP::coff == COFF::OVERLAP) {
         uint32_t coff = static_cast<uint32_t>(COMP::coff);
+
+        if (sliceInfo.dealTcSize > 1) {
+            // The later state saves cover the tail-side windows only. For a
+            // batched verifier call, also persist the first current block so
+            // every possible accepted prefix has the same state as serial
+            // one-token compression.
+            uint32_t firstCopySeqCnt = constInfo_.cmpRatio - sliceInfo.headHolderSeqCnt;
+            if (firstCopySeqCnt > sliceInfo.validSeqCnt) {
+                firstCopySeqCnt = sliceInfo.validSeqCnt;
+            }
+
+            uint64_t startSeqIdx = sliceInfo.bStartPos + sliceInfo.sIdx;
+            uint64_t endSeqIdx = startSeqIdx + firstCopySeqCnt;
+            uint64_t leftSrcBaseOffset =
+                (sliceInfo.preValidSeqCnt + sliceInfo.preTailHolderSeqCnt + sliceInfo.headHolderSeqCnt) *
+                coff * dDealSize;
+            uint64_t rightSrcBaseOffset = sliceInfo.headHolderSeqCnt * coff * dDealSize + dDealSize;
+            WriteToCacheState(kvStateGm_, kvBlockTableGm_, kvLocal[leftSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx, dDealSize);
+            WriteToCacheState(scoreStateGm_, scoreBlockTableGm_, scoreLocal[leftSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx, dDealSize);
+            WriteToCacheState(kvStateGm_, kvBlockTableGm_, kvLocal[rightSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx + constInfo_.headDim, dDealSize);
+            WriteToCacheState(scoreStateGm_, scoreBlockTableGm_, scoreLocal[rightSrcBaseOffset], sliceInfo.bIdx,
+                startSeqIdx, endSeqIdx, dStartIdx + constInfo_.headDim, dDealSize);
+        }
+
         // 存右边
         if (sliceInfo.sIdx + sliceInfo.validSeqCnt == sliceInfo.bSeqUsed) {
             uint32_t copySeqCnt = constInfo_.cmpRatio - sliceInfo.tailHolderSeqCnt;

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -134,6 +134,15 @@ def pad_to_blocks(x: torch.Tensor,
     return out
 
 
+def _get_oproj_static_exchange_tokens(vllm_config: VllmConfig) -> int:
+    compilation_config = vllm_config.compilation_config
+    capture_sizes = compilation_config.cudagraph_capture_sizes
+    if capture_sizes:
+        return int(compilation_config.max_cudagraph_capture_size
+                   or max(capture_sizes))
+    return int(vllm_config.scheduler_config.max_num_batched_tokens)
+
+
 class AscendDSABackend(AttentionBackend):
     accept_output_buffer: bool = True
 
@@ -1243,12 +1252,30 @@ class AscendDSAImpl(DSAAttentionImpl):
                     f"and {oproj_tp_size}.")
 
             groups_per_oproj_rank = self.n_local_groups // oproj_tp_size
-            o_proj_input = o_proj_input.view(num_tokens, oproj_tp_size,
+            local_num_tokens = num_tokens
+            exchange_num_tokens = _get_oproj_static_exchange_tokens(
+                self.vllm_config)
+            if exchange_num_tokens < local_num_tokens:
+                raise ValueError(
+                    "oproj_tensor_parallel_size requires static exchange "
+                    "capacity to cover local tokens, got "
+                    f"{exchange_num_tokens} and {local_num_tokens}.")
+
+            o_proj_input = o_proj_input.view(local_num_tokens, oproj_tp_size,
                                              groups_per_oproj_rank, -1)
-            send = o_proj_input.transpose(1, 0).contiguous().view(-1)
+            if exchange_num_tokens == local_num_tokens:
+                send = o_proj_input.transpose(1, 0).contiguous().view(-1)
+            else:
+                # Keep OTP collectives graph-static across uneven DP ranks.
+                send = o_proj_input.new_zeros(
+                    (oproj_tp_size, exchange_num_tokens,
+                     groups_per_oproj_rank, o_proj_input.shape[-1]))
+                send[:, :local_num_tokens].copy_(
+                    o_proj_input.transpose(1, 0))
+                send = send.view(-1)
             recv = torch.empty_like(send)
             dist.all_to_all_single(recv, send, group=oproj_group.device_group)
-            o_proj_input = recv.view(oproj_tp_size * num_tokens,
+            o_proj_input = recv.view(oproj_tp_size * exchange_num_tokens,
                                      groups_per_oproj_rank, -1)
             o_proj_input = torch_npu.npu_transpose_batchmatmul(
                 o_proj_input,
@@ -1259,10 +1286,11 @@ class AscendDSAImpl(DSAAttentionImpl):
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
                 batch_split_factor=1)
-            o_proj_input = o_proj_input.reshape(oproj_tp_size * num_tokens,
-                                                -1)
+            o_proj_input = o_proj_input.reshape(
+                oproj_tp_size * exchange_num_tokens, -1)
             o_proj_output = self.wo_b(o_proj_input)
-            output[...] = oproj_group.reduce_scatter(o_proj_output, dim=0)
+            o_proj_output = oproj_group.reduce_scatter(o_proj_output, dim=0)
+            output[...] = o_proj_output[:local_num_tokens]
         else:
             # wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
             # o = torch.einsum("tgd,grd->tgr", o, wo_a)

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -751,9 +751,22 @@ class AscendMLAImpl(MLAAttentionImpl):
             graph_params = get_graph_params()
         # FIXME: Behold! We are using a temporary hack here to update the args
         # for each layer's attention op in the graph.
+        if _EXTRA_CTX.is_draft_model and draft_attn_metadatas is not None:
+            attn_metadata = draft_attn_metadatas
+            attn_keys = list(attn_metadata[0].keys())
+        else:
+            attn_metadata = forward_context.attn_metadata
+            attn_keys = list(attn_metadata.keys())
+        num_layers = len(attn_keys)
+        if num_layers == 0:
+            return
+        if _EXTRA_CTX.is_draft_model:
+            attn_keys = attn_keys * (len(graph_params.attn_params[num_tokens]) // num_layers)
+
+        attn_count = 0
         with torch.npu.stream(update_stream):
             for key, param, handle, event in zip(
-                forward_context.attn_metadata,
+                attn_keys,
                 graph_params.attn_params[num_tokens],
                 graph_params.handles[num_tokens],
                 graph_params.events[num_tokens],
@@ -778,15 +791,22 @@ class AscendMLAImpl(MLAAttentionImpl):
                     dequant_scale_q_nope,
                     fak_descale_float,
                 ) = param
-                seq_lens_list = forward_context.attn_metadata[key].decode.seq_lens_list
+                if _EXTRA_CTX.is_draft_model and draft_attn_metadatas is not None:
+                    draft_step = attn_count // num_layers
+                    decode_meta = attn_metadata[draft_step][key].decode
+                    attn_count += 1
+                else:
+                    decode_meta = attn_metadata[key].decode
+
+                seq_lens_list = decode_meta.seq_lens_list
                 if speculative_config and speculative_config.method == "mtp" and not _EXTRA_CTX.is_draft_model:
-                    actual_seq_lengths = forward_context.attn_metadata[key].decode.actual_seq_lengths_q
+                    actual_seq_lengths = decode_meta.actual_seq_lengths_q
                     spec_multiple = speculative_config.num_speculative_tokens + 1
                     seq_lens_list = seq_lens_list + [0] * (num_tokens // spec_multiple - len(seq_lens_list))
                     actual_seq_lengths = [spec_multiple * (i + 1) for i in range(num_tokens // spec_multiple)]
                 elif _EXTRA_CTX.is_draft_model:
-                    actual_seq_lengths = forward_context.attn_metadata[key].decode.actual_seq_lengths_q
-                    block_table = forward_context.attn_metadata[key].decode.block_table
+                    actual_seq_lengths = decode_meta.actual_seq_lengths_q
+                    block_table = decode_meta.block_table
                     # TODO: This is a hack and should be fixed in the future.
                     if speculative_config.disable_padded_drafter_batch:
                         block_table = block_table[: len(actual_seq_lengths)]

--- a/vllm_ascend/models/deepseek_v4_mtp.py
+++ b/vllm_ascend/models/deepseek_v4_mtp.py
@@ -122,21 +122,21 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         inputs_embeds = torch.where(
             positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
+        if previous_hidden_states.shape[-1] == self.config.hidden_size:
+            previous_hidden_states = previous_hidden_states.unsqueeze(1).repeat(
+                1, self.hc_mult, 1)
+        else:
+            previous_hidden_states = previous_hidden_states.view(
+                -1, self.hc_mult, self.config.hidden_size)
         previous_hidden_states = self.hnorm(previous_hidden_states)
-
-        hidden_states = (self.e_proj(inputs_embeds) +
+        hidden_states = (self.e_proj(inputs_embeds).unsqueeze(1) +
                          self.h_proj(previous_hidden_states))
-
-        hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
 
         hidden_states, residual = self.mtp_block(positions=positions,
                                                  hidden_states=hidden_states,
                                                  residual=None)
 
-        hidden_states = self.hc_head(hidden_states, self.hc_head_fn,
-                                     self.hc_head_scale, self.hc_head_base)
-
-        return hidden_states
+        return hidden_states.flatten(1)
 
     def hc_head(self, x: torch.Tensor, hc_fn: torch.Tensor,
                 hc_scale: torch.Tensor, hc_base: torch.Tensor):
@@ -175,6 +175,23 @@ class DeepSeekMultiTokenPredictor(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    @staticmethod
+    def _select_local_tokens(tensor: torch.Tensor,
+                             target_num_tokens: int) -> torch.Tensor:
+        if tensor.shape[0] == target_num_tokens:
+            return tensor
+        tp_world_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        chunk_size = (tensor.shape[0] + tp_world_size - 1) // tp_world_size
+        start = chunk_size * tp_rank
+        local_tensor = tensor[start:start + chunk_size]
+        if local_tensor.shape[0] == target_num_tokens:
+            return local_tensor
+        output = tensor.new_zeros((target_num_tokens, *tensor.shape[1:]))
+        num_tokens = min(local_tensor.shape[0], target_num_tokens)
+        output[:num_tokens].copy_(local_tensor[:num_tokens])
+        return output
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -186,7 +203,19 @@ class DeepSeekMultiTokenPredictor(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         current_step_idx = spec_step_idx % self.num_mtp_layers
-        return self.layers[str(current_step_idx)](
+        mtp_layer = self.layers[str(current_step_idx)]
+        if previous_hidden_states.shape[-1] == mtp_layer.config.hidden_size:
+            target_num_tokens = previous_hidden_states.shape[0]
+        else:
+            target_num_tokens = (previous_hidden_states.numel() //
+                                 (mtp_layer.hc_mult *
+                                  mtp_layer.config.hidden_size))
+        if inputs_embeds.shape[0] != target_num_tokens:
+            inputs_embeds = self._select_local_tokens(inputs_embeds,
+                                                      target_num_tokens)
+        if positions.dim() == 1 and positions.shape[0] != target_num_tokens:
+            positions = self._select_local_tokens(positions, target_num_tokens)
+        return mtp_layer(
             input_ids,
             positions,
             previous_hidden_states,
@@ -201,6 +230,11 @@ class DeepSeekMultiTokenPredictor(nn.Module):
     ) -> torch.Tensor:
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[str(current_step_idx)]
+        hidden_states = hidden_states.view(
+            -1, mtp_layer.hc_mult, mtp_layer.config.hidden_size)
+        hidden_states = mtp_layer.hc_head(hidden_states, mtp_layer.hc_head_fn,
+                                          mtp_layer.hc_head_scale,
+                                          mtp_layer.hc_head_base)
         logits = self.logits_processor(mtp_layer.shared_head.head,
                                        mtp_layer.shared_head(hidden_states))
         return logits
@@ -208,7 +242,6 @@ class DeepSeekMultiTokenPredictor(nn.Module):
 
 @support_torch_compile
 class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
-
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -273,6 +273,18 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
             # Also slice mc2_mask
             split_mc2_mask = torch.tensor_split(mc2_mask, self.tp_size, dim=0)
             mc2_mask = split_mc2_mask[self.tp_rank]
+        if (replace_allreduce and _EXTRA_CTX.is_draft_model
+                and mc2_mask is not None
+                and mc2_mask.shape[0] != hidden_states.shape[0]):
+            local_mask_len = hidden_states.shape[0]
+            full_mask_len = local_mask_len * self.tp_size
+            full_mask = _EXTRA_CTX.mc2_mask[:full_mask_len]
+            if full_mask.shape[0] < full_mask_len:
+                full_mask = nn.functional.pad(
+                    full_mask, (0, full_mask_len - full_mask.shape[0]),
+                    value=False)
+            mc2_mask = torch.tensor_split(full_mask, self.tp_size,
+                                          dim=0)[self.tp_rank]
 
         padded_hidden_states_shape = hidden_states.shape
         if not self.replace_allreduce:

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -91,6 +91,18 @@ class SpecDecodeBaseProposer(EagleProposer):
     def __init__(self, vllm_config: VllmConfig, device: torch.device, pass_hidden_states_to_model: bool, runner=None):
         super().__init__(vllm_config, device, runner)
 
+        draft_hf_config = self.draft_model_config.hf_config
+        if (self.method == "mtp"
+                and getattr(draft_hf_config, "model_type", None)
+                == "deepseek_v4"
+                and hasattr(draft_hf_config, "hc_mult")):
+            self.hidden_size *= draft_hf_config.hc_mult
+            self.hidden_states = torch.zeros(
+                (self.max_num_tokens, self.hidden_size),
+                dtype=self.dtype,
+                device=device,
+            )
+
         self.use_async_scheduling = self.vllm_config.scheduler_config.async_scheduling
         self.use_compress = hasattr(self.vllm_config.model_config.hf_config, "compress_ratios")
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
@@ -176,6 +188,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             self.positions = torch.zeros(self.max_num_tokens, dtype=torch.int32, device=device)
 
         self.token_arange_np = np.arange(self.max_num_tokens + 1)
+        self.mtp_initial_hidden_states: torch.Tensor | None = None
 
     def _get_model(self) -> nn.Module:
         """
@@ -618,14 +631,10 @@ class SpecDecodeBaseProposer(EagleProposer):
         common_attn_metadata.slot_mapping = self.slot_mapping_group[0]
         common_attn_metadata.num_input_tokens = num_input_tokens
         # FIXME(woosuk): The below two ops cause synchronization. Optimize.
-        assert len(self.draft_attn_groups) > 0
-        builder = self.draft_attn_groups[0].get_metadata_builder()
         extra_attn_metadata_args = dict(
                     prefill_ratio_to_sas_metadata=dict(),
                     decode_ratio_to_sas_metadata=dict(),
                     common_ratio_to_sas_metadata=dict())
-        attn_metadata = builder.build(0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args)
-        attn_metadata = self._freeze_draft_step_attn_metadata(attn_metadata)
 
         if self.uses_mrope:
             used_update_positions = self.mrope_positions[:, token_indices_to_sample]
@@ -633,8 +642,14 @@ class SpecDecodeBaseProposer(EagleProposer):
             used_update_positions = self.positions[token_indices_to_sample]
         per_layer_attn_metadata = dict()
         # The first step of speculative.
-        for layer_name in self.attn_layer_names:
-            per_layer_attn_metadata[layer_name] = [attn_metadata]
+        assert len(self.draft_attn_groups) > 0
+        for attn_group in self.draft_attn_groups:
+            builder = attn_group.get_metadata_builder()
+            attn_metadata = builder.build(
+                0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args)
+            attn_metadata = self._freeze_draft_step_attn_metadata(attn_metadata)
+            for layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[layer_name] = [attn_metadata]
         multi_steps_attn_metadata = [per_layer_attn_metadata]
 
         # Copy the old attn_metadata and update
@@ -695,7 +710,7 @@ class SpecDecodeBaseProposer(EagleProposer):
                 if not self.parallel_drafting:
                     for draft_step in range(1, self.num_speculative_tokens):
                         per_layer_attn_metadata = dict()
-                        for attn_group in self.draft_attn_groups:
+                        for group_idx, attn_group in enumerate(self.draft_attn_groups):
                             common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
                                 draft_step,
                                 attn_metadata,
@@ -707,10 +722,12 @@ class SpecDecodeBaseProposer(EagleProposer):
                                 ori_seq_len,
                                 slot_indices,
                                 mtp_slot_mapping,
+                                num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                                advance_metadata=group_idx == 0,
                                 attn_group=attn_group,
                             )
                             attn_metadata = self._freeze_draft_step_attn_metadata(attn_metadata)
-                            for layer_name in self.attn_layer_names:
+                            for layer_name in attn_group.layer_names:
                                 per_layer_attn_metadata[layer_name] = [attn_metadata]
                         multi_steps_attn_metadata.append(per_layer_attn_metadata)
         else:
@@ -718,7 +735,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             if not self.parallel_drafting:
                 for draft_step in range(1, self.num_speculative_tokens):
                     per_layer_attn_metadata = dict()
-                    for attn_group in self.draft_attn_groups:
+                    for group_idx, attn_group in enumerate(self.draft_attn_groups):
                         common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
                             draft_step,
                             attn_metadata,
@@ -727,10 +744,12 @@ class SpecDecodeBaseProposer(EagleProposer):
                             num_input_tokens,
                             used_update_positions,
                             aclgraph_runtime_mode,
+                            num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                            advance_metadata=group_idx == 0,
                             attn_group=attn_group,
                         )
                         attn_metadata = self._freeze_draft_step_attn_metadata(attn_metadata)
-                        for layer_name in self.attn_layer_names:
+                        for layer_name in attn_group.layer_names:
                             per_layer_attn_metadata[layer_name] = [attn_metadata]
                     multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
@@ -793,7 +812,11 @@ class SpecDecodeBaseProposer(EagleProposer):
         }
 
         if self.pass_hidden_states_to_model:
-            model_hidden_states = self.hidden_states[:num_input_tokens]
+            if self.method == "mtp" and self.mtp_initial_hidden_states is not None:
+                model_hidden_states = self._pad_tensor(
+                    self.mtp_initial_hidden_states, num_input_tokens)
+            else:
+                model_hidden_states = self.hidden_states[:num_input_tokens]
             model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
             model_kwargs["hidden_states"] = model_hidden_states
             if self.method == "mtp":
@@ -819,7 +842,16 @@ class SpecDecodeBaseProposer(EagleProposer):
                 hidden_states, 0, self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: hidden_states.shape[0]]
             )
             if self.method == "mtp":
-                last_hidden_states = hidden_states
+                if last_hidden_states.shape == hidden_states.shape:
+                    last_hidden_states = hidden_states
+                else:
+                    last_hidden_states = last_hidden_states[:num_tokens]
+                    last_hidden_states = get_pcp_group().all_gather(last_hidden_states, 0)
+                    last_hidden_states = torch.index_select(
+                        last_hidden_states,
+                        0,
+                        self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: last_hidden_states.shape[0]],
+                    )
             else:
                 # eagle and eagle3 need allgather last_hidden_states.
                 last_hidden_states = last_hidden_states[:num_tokens]
@@ -909,7 +941,6 @@ class SpecDecodeBaseProposer(EagleProposer):
             # copy inputs to buffer for cudagraph
             self.input_ids[:batch_size] = input_ids
             self._set_positions(batch_size, clamped_positions)
-            self.hidden_states[:batch_size] = hidden_states
             if self.supports_mm_inputs:
                 self.inputs_embeds[:batch_size] = self.model.embed_input_ids(input_ids)
 
@@ -926,7 +957,12 @@ class SpecDecodeBaseProposer(EagleProposer):
             # `model_hidden_states` represent the speculative model inputs.
             model_input_ids = self.input_ids[:input_batch_size]
             model_positions = self._get_positions(input_batch_size)
-            model_hidden_states = self.hidden_states[:input_batch_size]
+            if (self.method == "mtp"
+                    and hidden_states.shape[1:] != self.hidden_states.shape[1:]):
+                model_hidden_states = self._pad_tensor(hidden_states, input_batch_size)
+            else:
+                self.hidden_states[:batch_size] = hidden_states
+                model_hidden_states = self.hidden_states[:input_batch_size]
 
             model_hidden_states, model_positions = self.maybe_pad_and_reduce(model_hidden_states, model_positions)
 
@@ -1075,7 +1111,12 @@ class SpecDecodeBaseProposer(EagleProposer):
                 target_positions = target_positions[0]
 
             self._set_positions(num_tokens, target_positions)
-            self.hidden_states[:num_tokens] = target_hidden_states
+            if (self.method == "mtp"
+                    and target_hidden_states.shape[1:] != self.hidden_states.shape[1:]):
+                self.mtp_initial_hidden_states = target_hidden_states
+            else:
+                self.mtp_initial_hidden_states = None
+                self.hidden_states[:num_tokens] = target_hidden_states
 
             return num_tokens, token_indices_to_sample, cad, (query_lens_d, ori_token_indices_to_sample)
         else:
@@ -1159,7 +1200,8 @@ class SpecDecodeBaseProposer(EagleProposer):
             return total_num_output_tokens, token_indices_to_sample, new_cad, None
 
     def model_returns_tuple(self) -> bool:
-        return self.method not in ("mtp", "draft_model")
+        return self.method not in ("mtp", "draft_model") or getattr(
+            self.model, "returns_hidden_states_tuple", False)
 
     def attn_update_stack_num_spec_norm(
         self,
@@ -1174,13 +1216,15 @@ class SpecDecodeBaseProposer(EagleProposer):
         ori_seq_len=None,
         slot_indices=None,
         mtp_slot_mapping=None,
+        num_rejected_tokens_gpu=None,
+        advance_metadata=True,
         attn_group=None,
     ):
         assert draft_step > 0
         assert attn_group is not None, "vllm-ascend v0.17.0rc1 requires attn_group"
         common_attn_metadata = self.shallow_copy_metadata(old_common_metadata)
 
-        if draft_step == 1:
+        if advance_metadata and draft_step == 1:
             if aclgraph_runtime_mode == CUDAGraphMode.FULL:
                 common_attn_metadata.num_reqs = input_batch_size
                 common_attn_metadata.block_table_tensor = self._pad_tensor(
@@ -1212,93 +1256,110 @@ class SpecDecodeBaseProposer(EagleProposer):
             common_attn_metadata.graph_pad_size = -1
             common_attn_metadata.num_input_tokens = input_batch_size
 
-        # The loop part
-        used_update_positions += 1
+        if advance_metadata:
+            # The loop part
+            used_update_positions += 1
 
-        # Clone the data so that when calculating the data at position 2 and position 3
-        # in the merged graph, it does not affect position 1
-        # FIXME(lilinsiman)
-        common_attn_metadata.seq_lens = common_attn_metadata.seq_lens.clone()
-        common_attn_metadata.seq_lens_cpu = common_attn_metadata.seq_lens_cpu.clone()
-        common_attn_metadata.num_computed_tokens_cpu = common_attn_metadata.num_computed_tokens_cpu.clone()
-        common_attn_metadata.positions = common_attn_metadata.positions.clone()
+            # Clone the data so that when calculating the data at position 2 and position 3
+            # in the merged graph, it does not affect position 1
+            # FIXME(lilinsiman)
+            common_attn_metadata.seq_lens = common_attn_metadata.seq_lens.clone()
+            common_attn_metadata.seq_lens_cpu = common_attn_metadata.seq_lens_cpu.clone()
+            common_attn_metadata.num_computed_tokens_cpu = common_attn_metadata.num_computed_tokens_cpu.clone()
+            common_attn_metadata.positions = common_attn_metadata.positions.clone()
+            common_attn_metadata.positions_cpu = common_attn_metadata.positions_cpu.clone()
 
-        # NOTE(woosuk): We should handle the case where the draft model
-        # generates tokens beyond the max model length. Since it is complex
-        # to remove such requests from the batch, we keep them in the batch
-        # but adjust the position ids and slot mappings to avoid the
-        # out-of-range access during the model execution. The draft tokens
-        # generated with this adjustment should be ignored.
-        if self.uses_mrope:
-            exceeds_max_model_len = used_update_positions[0] >= self.max_model_len
-            # Mask out the position ids that exceed the max model length.
-            # Otherwise, we may get out-of-range error in RoPE.
-            clamped_positions = torch.where(
-                exceeds_max_model_len.unsqueeze(0), torch.zeros_like(used_update_positions), used_update_positions
+            # NOTE(woosuk): We should handle the case where the draft model
+            # generates tokens beyond the max model length. Since it is complex
+            # to remove such requests from the batch, we keep them in the batch
+            # but adjust the position ids and slot mappings to avoid the
+            # out-of-range access during the model execution. The draft tokens
+            # generated with this adjustment should be ignored.
+            if self.uses_mrope:
+                exceeds_max_model_len = used_update_positions[0] >= self.max_model_len
+                # Mask out the position ids that exceed the max model length.
+                # Otherwise, we may get out-of-range error in RoPE.
+                clamped_positions = torch.where(
+                    exceeds_max_model_len.unsqueeze(0),
+                    torch.zeros_like(used_update_positions),
+                    used_update_positions)
+            else:
+                exceeds_max_model_len = used_update_positions >= self.max_model_len
+                clamped_positions = torch.where(exceeds_max_model_len, 0, used_update_positions)
+
+            # For data integrity when async scheduling, we shouldn't use in place
+            # operations in case they are modified in next step's `prepare_input`
+            # of main model.
+            # Increment the sequence lengths.
+            seq_len_delta = 1
+            if draft_step == 1 and num_rejected_tokens_gpu is not None:
+                seq_len_delta = 1 - num_rejected_tokens_gpu[:batch_size]
+
+            common_attn_metadata.seq_lens[:batch_size] += seq_len_delta
+            # For the requests that exceed the max model length, we set the
+            # sequence length to 1 to minimize their overheads in attention.
+            common_attn_metadata.seq_lens[:batch_size].masked_fill_(exceeds_max_model_len, 1)
+
+            if isinstance(seq_len_delta, torch.Tensor):
+                seq_len_delta_cpu = seq_len_delta.cpu()
+            else:
+                seq_len_delta_cpu = seq_len_delta
+            common_attn_metadata.seq_lens_cpu[:batch_size] = (
+                common_attn_metadata.seq_lens_cpu[:batch_size] + seq_len_delta_cpu
             )
-        else:
-            exceeds_max_model_len = used_update_positions >= self.max_model_len
-            clamped_positions = torch.where(exceeds_max_model_len, 0, used_update_positions)
+            exceeds_mask = common_attn_metadata.seq_lens_cpu[:batch_size] >= self.max_model_len
+            common_attn_metadata.seq_lens_cpu[:batch_size].masked_fill_(exceeds_mask, 1)
+            common_attn_metadata.num_computed_tokens_cpu[:batch_size] += seq_len_delta_cpu
+            if self.uses_mrope:
+                common_attn_metadata.positions[:batch_size].copy_(clamped_positions[0])
+                common_attn_metadata.positions_cpu[:batch_size] = clamped_positions[0].cpu()
+            else:
+                common_attn_metadata.positions[:batch_size].copy_(clamped_positions)
+                common_attn_metadata.positions_cpu[:batch_size] = clamped_positions.cpu()
 
-        # For data integrity when async scheduling, we shouldn't use in place
-        # operations in case they are modified in next step's `prepare_input`
-        # of main model.
-        # Increment the sequence lengths.
-        common_attn_metadata.seq_lens[:batch_size] += 1
-        # For the requests that exceed the max model length, we set the
-        # sequence length to 1 to minimize their overheads in attention.
-        common_attn_metadata.seq_lens[:batch_size].masked_fill_(exceeds_max_model_len, 1)
+            if self.pcp_size * self.dcp_size > 1:
+                # update slot_mapping
+                slot_indices += self.pcp_size
+                slot_mapping = mtp_slot_mapping[slot_indices]
+                self.slot_mapping_group[draft_step][: batch_size * self.pcp_size] = slot_mapping
+                common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
+            else:
+                # NOTE: In vllm, `block_size = attn_metadata_builder.kv_cache_spec.block_size`.
+                # However, in vllm-ascend, the above value can be multiple of `kernel_block_size`,
+                # which is not correct for computing `slot_mapping` below.
+                block_size = self.kernel_block_size
+                if not isinstance(block_size, int):
+                    block_size = 128
 
-        common_attn_metadata.seq_lens_cpu[:batch_size] = common_attn_metadata.seq_lens_cpu[:batch_size] + 1
-        exceeds_mask = common_attn_metadata.seq_lens_cpu[:batch_size] >= self.max_model_len
-        common_attn_metadata.seq_lens_cpu[:batch_size].masked_fill_(exceeds_mask, 1)
-        common_attn_metadata.num_computed_tokens_cpu[:batch_size] += 1
-        if self.uses_mrope:
-            common_attn_metadata.positions[:batch_size].copy_(clamped_positions[0])
-        else:
-            common_attn_metadata.positions[:batch_size].copy_(clamped_positions)
+                # Compute the slot mapping.
+                if self.uses_mrope:
+                    block_numbers = clamped_positions[0] // block_size
+                else:
+                    block_numbers = clamped_positions // block_size
+                block_ids = old_common_metadata.block_table_tensor.gather(dim=1, index=block_numbers.view(-1, 1))
+                block_ids = block_ids.view(-1)
+                if self.uses_mrope:
+                    slot_mapping = block_ids * block_size + clamped_positions[0] % block_size
+                else:
+                    slot_mapping = block_ids * block_size + clamped_positions % block_size
+
+                # Mask out the slot mappings that exceed the max model length.
+                # Otherwise, the KV cache will be inadvertently updated with the
+                # padding tokens.
+                slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)
+                self.slot_mapping_group[draft_step][: slot_mapping.shape[0]].copy_(slot_mapping.to(torch.int32))
+                self.slot_mapping_group[draft_step][slot_mapping.shape[0] :].fill_(PADDING_SLOT_ID)
+                # Set the address of the attn_metadata.slot_mapping to the self.slot_mapping_group[idx]
+                common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
 
         if self.pcp_size * self.dcp_size > 1:
             num_computed_tokens_of_pcp_dcp = self.runner.pcp_manager._get_cp_local_seq_lens(
-                ori_seq_len + draft_step + 1,
+                common_attn_metadata.seq_lens[:batch_size],
                 self.pcp_size,
                 self.dcp_size,
                 self.runner.parallel_config.cp_kv_cache_interleave_size,
             )
             cp_seq_len = num_computed_tokens_of_pcp_dcp[:, self.pcp_rank, self.dcp_rank]
-            # update slot_mapping
-            slot_indices += self.pcp_size
-            slot_mapping = mtp_slot_mapping[slot_indices]
-            self.slot_mapping_group[draft_step][: batch_size * self.pcp_size] = slot_mapping
-            common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
-        else:
-            # NOTE: In vllm, `block_size = attn_metadata_builder.kv_cache_spec.block_size`.
-            # However, in vllm-ascend, the above value can be multiple of `kernel_block_size`,
-            # which is not correct for computing `slot_mapping` below.
-            block_size = self.kernel_block_size
-            if not isinstance(block_size, int):
-                block_size = 128
-
-            # Compute the slot mapping.
-            if self.uses_mrope:
-                block_numbers = clamped_positions[0] // block_size
-            else:
-                block_numbers = clamped_positions // block_size
-            block_ids = old_common_metadata.block_table_tensor.gather(dim=1, index=block_numbers.view(-1, 1))
-            block_ids = block_ids.view(-1)
-            if self.uses_mrope:
-                slot_mapping = block_ids * block_size + clamped_positions[0] % block_size
-            else:
-                slot_mapping = block_ids * block_size + clamped_positions % block_size
-
-            # Mask out the slot mappings that exceed the max model length.
-            # Otherwise, the KV cache will be inadvertently updated with the
-            # padding tokens.
-            slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)
-            self.slot_mapping_group[draft_step][: slot_mapping.shape[0]].copy_(slot_mapping.to(torch.int32))
-            self.slot_mapping_group[draft_step][slot_mapping.shape[0] :].fill_(PADDING_SLOT_ID)
-            # Set the address of the attn_metadata.slot_mapping to the self.slot_mapping_group[idx]
-            common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
 
         attn_metadata_builder = attn_group.get_metadata_builder()
         extra_attn_metadata_args = dict(
@@ -1458,7 +1519,8 @@ class SpecDecodeBaseProposer(EagleProposer):
         #  q1 + 0, q1 + 1, q1 + 2, q1 + 3,       // req 2
         #  q1 + q2 + 0, q1 + q2 + 1, q1 + q2 + 2] // req 3
         token_indices_np = token_offsets + old_query_start_locs_expanded
-        token_indices = torch.from_numpy(token_indices_np).to(device, non_blocking=True)
+        token_indices_cpu = torch.from_numpy(token_indices_np)
+        token_indices = token_indices_cpu.to(device, non_blocking=True)
 
         common_attn_metadata.slot_mapping[: token_indices.shape[0]].copy_(
             common_attn_metadata.slot_mapping[token_indices]
@@ -1482,7 +1544,7 @@ class SpecDecodeBaseProposer(EagleProposer):
             slot_mapping=common_attn_metadata.slot_mapping,
             actual_seq_lengths_q=self.runner.actual_seq_lengths_q,
             positions=common_attn_metadata.positions[token_indices],
-            positions_cpu=common_attn_metadata.positions_cpu[token_indices],
+            positions_cpu=common_attn_metadata.positions_cpu[token_indices_cpu],
             attn_state=self.runner.attn_state,
             decode_token_per_req=self.runner.decode_token_per_req,
             max_seq_len=0,
@@ -1688,7 +1750,12 @@ class SpecDecodeBaseProposer(EagleProposer):
                 )
                 positions = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(positions.contiguous(), True)
                 if hidden_states is not None:
-                    hidden_states = last_hidden_states
+                    if hidden_states.shape == last_hidden_states.shape:
+                        hidden_states = last_hidden_states
+                    else:
+                        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                            hidden_states.contiguous(), True
+                        )
         else:
             if _EXTRA_CTX.flash_comm_v1_enabled:
                 last_hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1801,7 +1801,7 @@ class NPUModelRunner(GPUModelRunner):
         hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
         pad_size = get_forward_context().pad_size
         if pad_size > 0:
-            hidden_states = hidden_states[:-pad_size, :]
+            hidden_states = hidden_states[:-pad_size]
 
         return hidden_states
 


### PR DESCRIPTION
## Summary

Fixes #131.

Fix DeepSeek-V4 MTP accuracy regression and improve mtp=3 acceptance on Ascend.

Key changes:
- Persist the first current block state in overlap compressor `SaveState()` for batched verifier correctness.
- Keep DeepSeek-V4 MTP hidden states in `hc_mult * hidden_size` form and apply `hc_head` during logits computation.
- Build draft attention metadata per draft attention group and advance shared metadata only once per recursive draft step.
- Account for rejected tokens when updating recursive draft metadata.
- Fix MTP/TP/MC2 shape handling for draft hidden states and masks.

## Validation

Real-weight validation on `/models/DeepSeek-V4-Flash-w8a8-mtp`, `num_speculative_tokens=3`, `method=mtp`:

- Smoke chat request: HTTP 200, non-empty output.
- Long deterministic request: `请默写《滕王阁序》全文。`
- Best observed metrics:
  - `draft_tokens/draft = 3.0`
  - `mean_accept_len = 2.769`
  - `pos_accept = {0: 0.980, 1: 0.637, 2: 0.152}`

Artifacts:
- `artifacts/20260513T134152Z_mtp3_rebuilt_custom_ops`
- `artifacts/20260513T162124Z_mtp3_flat_hc_dense_fallback_live`

## Notes

Tried and rejected:
- target pre-`hc_head` hidden buffer: regressed to `mean_accept_len ~= 1.09`
- recursive draft step using raw `batch_size`: failed TP reduce-scatter shape alignment
- disabling flashcomm1: regressed to `mean_accept_len ~= 2.38`

Remaining gap:
GPU reference for mtp=3 is around `3.1`, while this patch reaches around `2.77`. The remaining loss is concentrated at pos2 and likely needs a separate follow-up on MTP recursive self-conditioning / hidden transfer semantics.
